### PR TITLE
Publish sas 1.0.0 and various tidying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-java/build
-java/dist
-java/out
-java/remoteapi.iws
-sas/authTest.sas
-sas/dist
+labkey-client-api/.gradle/
+labkey-client-api/build
+labkey-client-api/dist
+labkey-client-api/out
+labkey-api-sas/authTest.sas
+labkey-api-sas/dist
+labkey-api-sas/.gradle/
+labkey-api-sas/build/
+labkey-api-sas/dist/

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ See the individual packages' documentation for more information.
 | Package |  |  |  |
 | --- | --- | --- | --- |
 | java | [README](labkey-client-api/README.md) | [Change log](labkey-client-api/CHANGELOG.md) | [labkey.org docs](https://www.labkey.org/Documentation/wiki-page.view?name=javaAPI)
-| sas | [README](labkey-api-sas/README.md) | [Change log](labkey-api-sas/CHANGELOG.md) | [docs](https://www.labkey.org/Documentation/wiki-page.view?name=sasAPI)
+| sas | [README](labkey-api-sas/README.md) | [Change log](labkey-api-sas/CHANGELOG.md) | [labkey.org docs](https://www.labkey.org/Documentation/wiki-page.view?name=sasAPI)

--- a/labkey-api-sas/CHANGELOG.md
+++ b/labkey-api-sas/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for SAS - Change Log
 
 ## version 1.0.0
-*Released* : TBD
+*Released* : 5 June 2020
 
 * Initial publication using [SemVer](https://semver.org/) for library versioning.
   With 1.0.0, we will move away from using the LabKey server version 

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -57,7 +57,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/sas")
 
 group 'org.labkey.api'
 
-version '1.1.0-SNAPSHOT'
+version '1.0.0-SNAPSHOT'
 
 // We add the TeamCity extension here if it doesn't exist because we will use the build
 // number property from TeamCity in the distribution artifact names, if present.

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -57,7 +57,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/sas")
 
 group 'org.labkey.api'
 
-version '1.0.0-SNAPSHOT'
+version '1.0.0'
 
 // We add the TeamCity extension here if it doesn't exist because we will use the build
 // number property from TeamCity in the distribution artifact names, if present.

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -57,7 +57,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/sas")
 
 group 'org.labkey.api'
 
-version '1.0.0'
+version '1.1.0-SNAPSHOT'
 
 // We add the TeamCity extension here if it doesn't exist because we will use the build
 // number property from TeamCity in the distribution artifact names, if present.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+#### Rationale
+<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->
+
+#### Related Pull Requests
+* <!-- list of links to related pull requests (replace this comment) -->
+
+#### Changes
+* <!-- list of descriptions of changes that are worth noting (replace this comment) -->


### PR DESCRIPTION
#### Rationale
First independently versioned publication for labkey-api-sas.  The zip file was published locally as 1.0.0 then the snapshot version was updated to the next patch release.

#### Changes
* Update to next snapshot version
* Various tidying