### PR TITLE
Release v1.3.0

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,8 +1,9 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version TBD
-*Released* : TBD
+## version 1.3.0
+*Released* : 16 June 2020
 
+* 7368: Conditional Formats of Fields
 * Update FileNotificationCommand to do a POST, as now required
 * Add documentation
 
@@ -17,7 +18,7 @@
 
 * Support for plate metadata in saveBatch and importRun APIs
 * Don't post invalid 'rangeURI' to server
-* Update source compatability to 1.8
+* Update source compatibility to 1.8
 
 ## version 1.0.0
 *Released*: 06 February 2020

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -175,7 +175,7 @@ project.afterEvaluate {
                     scm {
                         connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
                         developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/java'
+                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
                     }
                 }
 

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.0"
+version "1.4.0-SNAPSHOT"
 
 dependencies {
     api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.0-SNAPSHOT"
+version "1.3.0"
 
 dependencies {
     api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -246,7 +246,7 @@ if (project.hasProperty('bintray_user')
         pkg {
             repo = project.version.endsWith('SNAPSHOT') ? 'libs-snapshot' : 'libs-release'
             desc = libDescription
-            websiteUrl = orgUrl
+            websiteUrl = PomFileHelper.LABKEY_ORG_URL
             name = project.name
             userOrg = 'labkey'
             licenses = ['Apache-2.0']


### PR DESCRIPTION
#### Rationale
Release `v1.3.0` of Java Client API. Note, this is not being squash merged to allow `v1.3.0` tag to persist.

#### Changes
* CHANGELOG updates
* Minor fixes for `build.gradle`