### PR TITLE
Facilitate running automated tests without database login

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version 1.3.1 (TBD)
+*Released* : TBD
+
+* Fix pre-population of session and CSRF token
+
 ## version 1.3.0
 *Released* : 16 June 2020
 

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## version 1.3.1 (TBD)
 *Released* : TBD
 
-* Fix pre-population of session and CSRF token
+* Fix pre-population of session ID and CSRF token in Connection
+* Identify target server with a `URI` instead of a `String` 
 
 ## version 1.3.0
 *Released* : 16 June 2020

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.1-csrf-SNAPSHOT"
+version "1.3.1-SNAPSHOT"
 
 dependencies {
     api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.4.0-SNAPSHOT"
+version "1.3.1-csrf-SNAPSHOT"
 
 dependencies {
     api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
@@ -19,7 +19,7 @@ import org.apache.http.auth.AuthenticationException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
-import java.net.URISyntaxException;
+import java.net.URI;
 
 /**
  * Created by adam on 4/15/2016.
@@ -34,7 +34,7 @@ public class ApiKeyCredentialsProvider implements CredentialsProvider
     }
 
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
         request.setHeader("apikey", _apiKey);
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/BasicAuthCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/BasicAuthCredentialsProvider.java
@@ -25,7 +25,6 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * Created by adam on 4/15/2016.
@@ -42,9 +41,9 @@ public class BasicAuthCredentialsProvider implements CredentialsProvider
     }
 
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
-        AuthScope scope = new AuthScope(new URI(baseUrl).getHost(), AuthScope.ANY_PORT, AuthScope.ANY_REALM);
+        AuthScope scope = new AuthScope(baseURI.getHost(), AuthScope.ANY_PORT, AuthScope.ANY_REALM);
         BasicCredentialsProvider provider = new BasicCredentialsProvider();
         Credentials credentials = new UsernamePasswordCredentials(_email, _password);
         provider.setCredentials(scope, credentials);

--- a/labkey-client-api/src/org/labkey/remoteapi/Command.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Command.java
@@ -489,9 +489,7 @@ public class Command<ResponseType extends CommandResponse>
      */
     protected URI getActionUrl(Connection connection, String folderPath) throws URISyntaxException
     {
-        //start with the connection's base URL
-        // Use a URI so that it correctly encodes each section of the overall URI
-        URI uri = new URI(connection.getBaseUrl().replace('\\','/'));
+        URI uri = connection.getBaseURI();
 
         StringBuilder path = new StringBuilder(uri.getPath() == null || "".equals(uri.getPath()) ? "/" : uri.getPath());
 

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -20,13 +20,11 @@ import org.apache.http.HttpRequest;
 import org.apache.http.auth.AuthenticationException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.BasicCookieStore;
@@ -34,6 +32,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.ssl.SSLContextBuilder;
 import org.labkey.remoteapi.security.EnsureLoginCommand;
 import org.labkey.remoteapi.security.ImpersonateUserCommand;
 import org.labkey.remoteapi.security.LogoutCommand;
@@ -236,7 +235,8 @@ public class Connection
 
     protected void beforeExecute(HttpRequest request) throws IOException, CommandException
     {
-        if (null == _csrf && request instanceof HttpPost)
+        if (null == _csrf &&
+                request instanceof HttpRequestBase && !"GET".equals(((HttpRequestBase) request).getMethod()))
         {
             // make a request to get a JSESSIONID
             try

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -102,6 +102,8 @@ public class Connection
 {
     private static final int DEFAULT_TIMEOUT = 60000;    // 60 seconds
     private static final HttpClientConnectionManager _connectionManager = new PoolingHttpClientConnectionManager();
+    private static final String X_LABKEY_CSRF = "X-LABKEY-CSRF";
+    private static final String JSESSIONID = "JSESSIONID";
 
     private final String _baseUrl;
     private final CredentialsProvider _credentialsProvider;
@@ -113,6 +115,7 @@ public class Connection
     private String _proxyHost;
     private Integer _proxyPort;
     private String _csrf;
+    private String _sessionId;
 
     // The user email when impersonating a user
     private String _impersonateUser;
@@ -244,7 +247,9 @@ public class Connection
             }
         }
         if (null != _csrf)
-            request.setHeader("X-LABKEY-CSRF", _csrf);
+            request.setHeader(X_LABKEY_CSRF, _csrf);
+        if (null != _sessionId)
+            request.setHeader(JSESSIONID, _csrf);
     }
 
 
@@ -253,8 +258,11 @@ public class Connection
         // Always update our CSRF token as the session may be new since our last request
         for (Cookie c : _httpClientContext.getCookieStore().getCookies())
         {
-            if ("JSESSIONID".equals(c.getName()))
+            if (X_LABKEY_CSRF.equals(c.getName()))
                 _csrf = c.getValue();
+
+            if (JSESSIONID.equals(c.getName()))
+                _sessionId = c.getValue();
         }
     }
 
@@ -462,6 +470,12 @@ public class Connection
         cookie.setExpiryDate(expiry);
         cookie.setSecure(isSecure);
         _httpClientContext.getCookieStore().addCookie(cookie);
+
+        if (X_LABKEY_CSRF.equals(name))
+            _csrf = value;
+        if (JSESSIONID.equals(name))
+            _sessionId = value;
+
         return this;
     }
 

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -145,7 +145,7 @@ public class Connection
     {
         try
         {
-            _baseURI = new URI(getBaseUrl());
+            _baseURI = new URI(baseUrl);
         }
         catch (URISyntaxException e)
         {

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -100,10 +100,11 @@ import java.util.Objects;
  */
 public class Connection
 {
+    public static final String X_LABKEY_CSRF = "X-LABKEY-CSRF";
+    public static final String JSESSIONID = "JSESSIONID";
+
     private static final int DEFAULT_TIMEOUT = 60000;    // 60 seconds
     private static final HttpClientConnectionManager _connectionManager = new PoolingHttpClientConnectionManager();
-    private static final String X_LABKEY_CSRF = "X-LABKEY-CSRF";
-    private static final String JSESSIONID = "JSESSIONID";
 
     private final String _baseUrl;
     private final CredentialsProvider _credentialsProvider;
@@ -249,7 +250,7 @@ public class Connection
         if (null != _csrf)
             request.setHeader(X_LABKEY_CSRF, _csrf);
         if (null != _sessionId)
-            request.setHeader(JSESSIONID, _csrf);
+            request.setHeader(JSESSIONID, _sessionId);
     }
 
 

--- a/labkey-client-api/src/org/labkey/remoteapi/CredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/CredentialsProvider.java
@@ -19,6 +19,7 @@ import org.apache.http.auth.AuthenticationException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
@@ -26,5 +27,14 @@ import java.net.URISyntaxException;
  */
 public interface CredentialsProvider
 {
-    void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException;
+    /**
+     * @deprecated Use {@link #configureRequest(URI, HttpUriRequest, HttpClientContext)}
+     */
+    @Deprecated
+    default void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    {
+        configureRequest(new URI(baseUrl), request, httpClientContext);
+    }
+
+    void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException;
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/GuestCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/GuestCredentialsProvider.java
@@ -18,18 +18,18 @@ package org.labkey.remoteapi;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
-/**
- * Created by adam on 4/15/2016.
- */
+import java.net.URI;
 
 /**
+ * Created by adam on 4/15/2016.
+ *
  * A credentials provider that provides no credentials. Connections using
  * this provider will be granted guest access only.
  */
 public class GuestCredentialsProvider implements CredentialsProvider
 {
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext)
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext)
     {
         httpClientContext.setCredentialsProvider(null);
         request.removeHeaders("Authenticate");

--- a/labkey-client-api/src/org/labkey/remoteapi/NetrcCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/NetrcCredentialsProvider.java
@@ -21,14 +21,11 @@ import org.apache.http.client.protocol.HttpClientContext;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 
 /**
  * Created by adam on 4/15/2016.
- */
-
-/**
+ *
  * Attempts to find a .netrc or _netrc file and entry for the given host. If found, it will attempt basic auth using
  * the email and password in the entry. If file or entry are not found, it connects as guest.
  */
@@ -65,8 +62,8 @@ public class NetrcCredentialsProvider implements CredentialsProvider
     }
 
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
-        _wrappedCredentialsProvider.configureRequest(baseUrl, request, httpClientContext);
+        _wrappedCredentialsProvider.configureRequest(baseURI, request, httpClientContext);
     }
 }


### PR DESCRIPTION
#### Rationale
In order for tests to authenticate against servers running without database authentication, they log in through the UI then populate the session and csrf cookies for client API `Connection`s. The client API, however, still attempts to authenticate via password. This change sets the session ID and CSRF token immediately if they are passed in via `addCookie`.
I'm not quite sure how this ever worked since we were grabbing the `JSESSIONID` cookie from the first request and using it to populate the `X-LABKEY-CSRF` header of subsequent requests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/369

#### Changes
* Don't create an initial session if session cookies were already populated.
* Pre-fetch CSRF token for any non-GET request. DELETEs via API started failing with recent server improvements

