### PR TITLE
Refactor URL Strings to URI

### DIFF
--- a/labkey-client-api/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
@@ -19,7 +19,7 @@ import org.apache.http.auth.AuthenticationException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
-import java.net.URISyntaxException;
+import java.net.URI;
 
 /**
  * Created by adam on 4/15/2016.
@@ -34,7 +34,7 @@ public class ApiKeyCredentialsProvider implements CredentialsProvider
     }
 
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
         request.setHeader("apikey", _apiKey);
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/BasicAuthCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/BasicAuthCredentialsProvider.java
@@ -25,7 +25,6 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * Created by adam on 4/15/2016.
@@ -42,9 +41,9 @@ public class BasicAuthCredentialsProvider implements CredentialsProvider
     }
 
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
-        AuthScope scope = new AuthScope(new URI(baseUrl).getHost(), AuthScope.ANY_PORT, AuthScope.ANY_REALM);
+        AuthScope scope = new AuthScope(baseURI.getHost(), AuthScope.ANY_PORT, AuthScope.ANY_REALM);
         BasicCredentialsProvider provider = new BasicCredentialsProvider();
         Credentials credentials = new UsernamePasswordCredentials(_email, _password);
         provider.setCredentials(scope, credentials);

--- a/labkey-client-api/src/org/labkey/remoteapi/Command.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Command.java
@@ -489,9 +489,7 @@ public class Command<ResponseType extends CommandResponse>
      */
     protected URI getActionUrl(Connection connection, String folderPath) throws URISyntaxException
     {
-        //start with the connection's base URL
-        // Use a URI so that it correctly encodes each section of the overall URI
-        URI uri = new URI(connection.getBaseUrl().replace('\\','/'));
+        URI uri = connection.getBaseURI();
 
         StringBuilder path = new StringBuilder(uri.getPath() == null || "".equals(uri.getPath()) ? "/" : uri.getPath());
 

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -180,7 +180,7 @@ public class Connection
      */
     public Connection(String baseUrl) throws URISyntaxException, IOException
     {
-        this(toURI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
+        this(toURI(baseUrl), new NetrcCredentialsProvider(toURI(baseUrl)));
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -180,7 +180,7 @@ public class Connection
      */
     public Connection(String baseUrl) throws URISyntaxException, IOException
     {
-        this(new URI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
+        this(toURI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -105,7 +105,6 @@ public class Connection
     private static final int DEFAULT_TIMEOUT = 60000;    // 60 seconds
     private static final HttpClientConnectionManager _connectionManager = new PoolingHttpClientConnectionManager();
 
-    private final String _baseUrl;
     private final URI _baseURI;
     private final CredentialsProvider _credentialsProvider;
     private final HttpClientContext _httpClientContext;
@@ -125,37 +124,49 @@ public class Connection
     /**
      * Constructs a new Connection object given a base URL and a credentials provider.
      * <p>
-     * The baseUrl parameter should include the protocol, domain name, port,
+     * The baseURI parameter should include the protocol, domain name, port,
      * and LabKey web application context path (if configured). For example
      * in a typical localhost configuration, the base URL would be:
      * </p>
-     * <code>http://localhost:8080/labkey</code>
+     * <code>new URI("http://localhost:8080/labkey")</code>
      * <p>
      * Note that https may also be used for the protocol. By default the
      * Connection is configured to deny self-signed SSL certificates.
      * If you want to accept self-signed certificates, use
      * <code>setAcceptSelfSignedCerts(false)</code> to enable this behavior.
      * </p>
-     * The email name and password should correspond to a valid user email
-     * and password on the target server.
-     * @param baseUrl The base URL
+     * @param baseURI Base URI for this Connection
      * @param credentialsProvider A credentials provider
      */
-    public Connection(String baseUrl, CredentialsProvider credentialsProvider)
+    public Connection(URI baseURI, CredentialsProvider credentialsProvider)
     {
-        try
+        if (baseURI.getHost() == null || baseURI.getScheme() == null)
         {
-            _baseURI = new URI(baseUrl);
+            throw new IllegalArgumentException("Invalid server URL: " + baseURI.toString());
         }
-        catch (URISyntaxException e)
-        {
-            throw new IllegalArgumentException("Invalid target server URL. " + baseUrl);
-        }
-        _baseUrl = baseUrl;
+        _baseURI = baseURI;
         _credentialsProvider = credentialsProvider;
         _httpClientContext = HttpClientContext.create();
         _httpClientContext.setCookieStore(new BasicCookieStore());
         setAcceptSelfSignedCerts(false);
+    }
+
+    /**
+     * Constructs a new Connection object given a base URL and a credentials provider.
+     * <p>
+     * The baseUrl parameter should include the protocol, domain name, port,
+     * and LabKey web application context path (if configured). For example
+     * in a typical localhost configuration, the base URL would be:
+     * </p>
+     * <code>http://localhost:8080/labkey</code>
+     * <p>
+     * @param baseUrl The base URL
+     * @param credentialsProvider A credentials provider
+     * @see #Connection(URI, CredentialsProvider)
+     */
+    public Connection(String baseUrl, CredentialsProvider credentialsProvider)
+    {
+        this(toURI(baseUrl), credentialsProvider);
     }
 
     /**
@@ -164,34 +175,49 @@ public class Connection
      * @param baseUrl The base URL
      * @throws URISyntaxException if the given url is not a valid URI
      * @throws IOException if there are problems reading the credentials
-     * @see #Connection(String, CredentialsProvider)
+     * @see NetrcCredentialsProvider
+     * @see #Connection(URI, CredentialsProvider)
      */
     public Connection(String baseUrl) throws URISyntaxException, IOException
     {
-        this(baseUrl, new NetrcCredentialsProvider(new URI(baseUrl)));
+        this(new URI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
     }
 
     /**
      * Constructs a new Connection object for a base URL that attempts basic authentication.
      * <p>
      * This is equivalent to calling <code>Connection(baseUrl, new BasicAuthCredentialsProvider(email, password))</code>.
+     * The email and password should correspond to a valid user email
+     * and password on the target server.
      * @param baseUrl The base URL
      * @param email The user email address to pass for authentication
      * @param password The user password to send for authentication
-     * @see #Connection(String, CredentialsProvider)
+     * @see BasicAuthCredentialsProvider#BasicAuthCredentialsProvider(String, String)
+     * @see #Connection(URI, CredentialsProvider)
      */
     public Connection(String baseUrl, String email, String password)
     {
-        this(baseUrl, new BasicAuthCredentialsProvider(email, password));
+        this(toURI(baseUrl), new BasicAuthCredentialsProvider(email, password));
     }
 
     /**
      * Returns the base URL for this connection.
      * @return The base URL.
+     * @deprecated Use {@link #getBaseURI()}
      */
+    @Deprecated
     public String getBaseUrl()
     {
-        return _baseUrl;
+        return _baseURI.toString();
+    }
+
+    /**
+     * Returns the base URI for this connection.
+     * @return The target LabKey instance's base URI
+     */
+    public URI getBaseURI()
+    {
+        return _baseURI;
     }
 
     /**
@@ -378,7 +404,7 @@ public class Connection
     CloseableHttpResponse executeRequest(HttpUriRequest request, Integer timeout) throws IOException, URISyntaxException, AuthenticationException
     {
         // Delegate authentication setup to CredentialsProvider
-        _credentialsProvider.configureRequest(getBaseUrl(), request, _httpClientContext);
+        _credentialsProvider.configureRequest(getBaseURI(), request, _httpClientContext);
 
         CloseableHttpClient client = getHttpClient();
 
@@ -502,4 +528,18 @@ public class Connection
         return hostPath.replaceAll("//+", "/").replaceFirst("/$", "");
     }
 
+    /**
+     * Utility method to construct a URI without modifying constructor signature
+     */
+    private static URI toURI(String baseUrl)
+    {
+        try
+        {
+            return new URI(baseUrl);
+        }
+        catch (URISyntaxException e)
+        {
+            throw new IllegalArgumentException("Invalid target server URL: " + baseUrl);
+        }
+    }
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/CredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/CredentialsProvider.java
@@ -19,6 +19,7 @@ import org.apache.http.auth.AuthenticationException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
@@ -26,5 +27,14 @@ import java.net.URISyntaxException;
  */
 public interface CredentialsProvider
 {
-    void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException;
+    /**
+     * @deprecated Use {@link #configureRequest(URI, HttpUriRequest, HttpClientContext)}
+     */
+    @Deprecated
+    default void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    {
+        configureRequest(new URI(baseUrl), request, httpClientContext);
+    }
+
+    void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException;
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/GuestCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/GuestCredentialsProvider.java
@@ -18,18 +18,18 @@ package org.labkey.remoteapi;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
-/**
- * Created by adam on 4/15/2016.
- */
+import java.net.URI;
 
 /**
+ * Created by adam on 4/15/2016.
+ *
  * A credentials provider that provides no credentials. Connections using
  * this provider will be granted guest access only.
  */
 public class GuestCredentialsProvider implements CredentialsProvider
 {
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext)
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext)
     {
         httpClientContext.setCredentialsProvider(null);
         request.removeHeaders("Authenticate");

--- a/labkey-client-api/src/org/labkey/remoteapi/NetrcCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/NetrcCredentialsProvider.java
@@ -21,14 +21,11 @@ import org.apache.http.client.protocol.HttpClientContext;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 
 /**
  * Created by adam on 4/15/2016.
- */
-
-/**
+ *
  * Attempts to find a .netrc or _netrc file and entry for the given host. If found, it will attempt basic auth using
  * the email and password in the entry. If file or entry are not found, it connects as guest.
  */
@@ -65,8 +62,8 @@ public class NetrcCredentialsProvider implements CredentialsProvider
     }
 
     @Override
-    public void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
+    public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
-        _wrappedCredentialsProvider.configureRequest(baseUrl, request, httpClientContext);
+        _wrappedCredentialsProvider.configureRequest(baseURI, request, httpClientContext);
     }
 }


### PR DESCRIPTION
#### Rationale
Convert to use URI. Isolating change from #7 for easier code review.

#### Related Pull Requests
* #7 

#### Changes
* Add primary constructor that takes a `URI`.
* Refactor credentials provider to take a `URI`.
