### PR TITLE
Restore support for Log4J 1 and update changelog

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -4,7 +4,8 @@
 *Released* : TBD
 
 * Fix pre-population of session ID and CSRF token in Connection
-* Identify target server with a `URI` instead of a `String` 
+* Identify target server with a `URI` instead of a `String`
+* Add support for Log4J 2
 
 ## version 1.3.0
 *Released* : 16 June 2020

--- a/labkey-client-api/src/log4j.xml
+++ b/labkey-client-api/src/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <priority value ="error" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
#### Rationale
The client API is backward compatible. We shouldn't drop support for Log4J 1 unnecessarily.

#### Related Pull Requests
* #9

#### Changes
* Restore `log4j.xml`
