### PR TITLE
Declare api and implementation dependencies to align with code usages

### DIFF
--- a/labkey-api-sas/gradle/wrapper/gradle-wrapper.properties
+++ b/labkey-api-sas/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix pre-population of session ID and CSRF token in Connection
 * Identify target server with a `URI` instead of a `String`
 * Add support for Log4J 2
+* Add some missing dependency declarations 
 
 ## version 1.3.0
 *Released* : 16 June 2020

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.1-depencencyHealth-SNAPSHOT"
+version "1.3.1-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -63,13 +63,17 @@ group "org.labkey.api"
 version "1.3.1-SNAPSHOT"
 
 dependencies {
-    api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
+    implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")
             {
                 // exclude this because it gets in the way of our own JSON object implementations from server/api
                 exclude group: "org.json", module:"json"
             }
-    api "net.sf.opencsv:opencsv:${opencsvVersion}"
+    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
+    implementation "commons-logging:commons-logging:${commonsLoggingVersion}"
+    api "org.apache.httpcomponents:httpclient:${httpclientVersion}"
+    implementation "commons-codec:commons-codec:${commonsCodecVersion}"
+    api "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
 }
 
 jar {

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.1-SNAPSHOT"
+version "1.3.1-depencencyHealth-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/gradle.properties
+++ b/labkey-client-api/gradle.properties
@@ -14,8 +14,12 @@ artifactoryPluginVersion=4.13.0
 bintrayPluginVersion=1.8.4
 gradlePluginsVersion=1.12.0
 
+commonsCodecVersion=1.10
+commonsLoggingVersion=1.2
 fluentHcVersion=4.3.5
 
+httpclientVersion=4.5.3
+httpcoreVersion=4.4.6
 httpmimeVersion=4.5.3
 
 jsonSimpleVersion=1.1

--- a/labkey-client-api/gradle/wrapper/gradle-wrapper.properties
+++ b/labkey-client-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Rationale
It is generally best practice to explicitly declare dependencies that are used in your code rather than relying on them to come through transitively.  Though in reality the risk of these transitive dependencies disappearing is low and would be easily noticed, the declaration of proper `api` dependencies will assure that our published `pom` files are accurate and others will not have to separately declare some dependencies that we rely on when using our jar files.

The changes made here were done with the help of this [Gradle dependency-analysis plugin](https://plugins.gradle.org/plugin/com.autonomousapps.dependency-analysis), which is still not at v1.0 and seems to have a few quirks, but my spot checks of the suggestions given seem like they provide solid advice.

#### Changes
* Update to latest Gradle version
* Update dependency declarations
