### PR TITLE
Release v1.3.1

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 1.3.1 (TBD)
-*Released* : TBD
+## version 1.3.1
+*Released* : 18 September 2020
 
 * Fix pre-population of session ID and CSRF token in Connection
 * Identify target server with a `URI` instead of a `String`

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.1"
+version "1.4.0-SNAPSHOT"
 
 dependencies {
     api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.1-SNAPSHOT"
+version "1.3.1"
 
 dependencies {
     api "org.apache.httpcomponents:httpmime:${httpmimeVersion}"


### PR DESCRIPTION
#### Rationale
Release `v1.3.1` of Java Client API. Note, this is not being squash merged to allow `v1.3.1` tag to persist.

#### Changes
* `v1.3.1` with tag. Published to Artifactory and Maven Central.
* Bump SNAPSHOT version post-release.
* CHANGELOG updates