### PR TITLE
Release v1.3.2

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,8 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version TBD
-*Released* :TBD
+## version 1.3.2
+*Released* : 05 November 2020
+* Fix `selectedMetadataInputFormat` serialization
 * Add some missing dependency declarations 
 
 ## version 1.3.1
@@ -10,7 +11,6 @@
 * Fix pre-population of session ID and CSRF token in Connection
 * Identify target server with a `URI` instead of a `String`
 * Add support for Log4J 2
-
 
 ## version 1.3.0
 *Released* : 16 June 2020

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.4.0-SNAPSHOT"
+version "1.3.2"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -60,7 +60,7 @@ buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
-version "1.3.2"
+version "1.4.0-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"


### PR DESCRIPTION
#### Rationale
Release `v1.3.2` of Java Client API. Note, this is not being squash merged to allow `v1.3.2` tag to persist.

I've left the current version as `1.4.0-SNAPSHOT`.

#### Changes
* `v1.3.2` with tag. Published to Artifactory and Maven Central.
* CHANGELOG updates.