### PR TITLE
Add no-arg constructor

### DIFF
--- a/labkey-client-api/src/org/labkey/remoteapi/query/Filter.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/Filter.java
@@ -217,6 +217,11 @@ public class Filter
         _value = source._value; //might be a shallow copy
     }
 
+    public Filter()
+    {
+        // No-arg constructor for serialization
+    }
+    
     public String getColumnName()
     {
         return _columnName;


### PR DESCRIPTION
@labkey-jeckels The intention here is to make Filter serializable by jackson. This would let us use this class directly to hold the ETL 'sourceFilters' I'd like to add support for in ETL. There might be a more sophisticated jackson/annotation mechanism to do this, or perhaps we could add something in the Pipeline's registered object serialzer/deserializer classes?