### PR TITLE
Replace use of bintray publishing with publishing to sonatype

### DIFF
--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -76,44 +76,46 @@ artifacts {
     archives project.tasks.distribution
 }
 
-project.publishing {
-    publications {
-        libs(MavenPublication) {
-            groupId = project.group
-            artifact project.tasks.distribution
-            pom {
-                name = "LabKey Server SAS Client API"
-                description = "Library of macros for use in accessing LabKey Server via SAS"
-                url = PomFileHelper.LABKEY_ORG_URL
-                developers PomFileHelper.getLabKeyTeamDevelopers()
-                licenses PomFileHelper.getApacheLicense()
-                organization PomFileHelper.getLabKeyOrganization()
-                scm {
-                    connection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
-                    developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
-                    url = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
+if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
+{
+    project.publishing {
+        publications {
+            libs(MavenPublication) {
+                groupId = project.group
+                artifact project.tasks.distribution
+                pom {
+                    name = "LabKey Server SAS Client API"
+                    description = "Library of macros for use in accessing LabKey Server via SAS"
+                    url = PomFileHelper.LABKEY_ORG_URL
+                    developers PomFileHelper.getLabKeyTeamDevelopers()
+                    licenses PomFileHelper.getApacheLicense()
+                    organization PomFileHelper.getLabKeyOrganization()
+                    scm {
+                        connection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
+                        developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
+                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
+                credentials {
+                    username = artifactory_user
+                    password = artifactory_password
+                }
+                authentication {
+                    basic(BasicAuthentication)
+                    // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
                 }
             }
         }
     }
-    repositories {
-        maven {
-            url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
-            credentials {
-                username = artifactory_user
-                password = artifactory_password
-            }
-            authentication {
-                basic(BasicAuthentication)
-                // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
-            }
+
+    project.model {
+        tasks.publishLibsPublicationToMavenLocal {
+            enabled = false
         }
     }
 }
-
-project.model {
-    tasks.publishLibsPublicationToMavenLocal {
-        enabled = false
-    }
-}
-

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -18,14 +18,6 @@ buildscript {
     }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-        // N.B.  We use the "old-fashioned" way of applying the artifactory plugin because if we use
-        // the plugins block below and specify a version number, the following error happens if building
-        // in conjunction with LabKey server (i.e., when including this project in the server's build.gradle
-        //    Error resolving plugin [id: 'com.jfrog.artifactory', version: '4.13.0', apply: false]
-        //    > Plugin request for plugin already on the classpath must not include a version
-        // We could instead include the plugin without a version number, which would work until
-        // some change in the latest version of the plugin came along that we aren't compatible with.
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:${artifactoryPluginVersion}"
     }
 }
 
@@ -52,9 +44,6 @@ repositories {
     }
 }
 
-// TODO remove once client-api distribution no longer requires this
-buildDir = new File(project.rootProject.buildDir, "/remoteapi/sas")
-
 group 'org.labkey.api'
 
 version '1.0.0-SNAPSHOT'
@@ -71,7 +60,6 @@ configurations {
 
 BuildUtils.addLabKeyDependency(project: project, config: "remoteApi", depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle), depVersion: project.labkeyClientApiVersion)
 
-// TODO change name and destination once client-api no longer requires this
 project.task("distribution",
         group: GroupNames.DISTRIBUTION,
         description: "Create a zip file for the SAS API client distribution containing the SAS macros, java client api jar and its dependencies",
@@ -88,59 +76,44 @@ artifacts {
     archives project.tasks.distribution
 }
 
-project.afterEvaluate {
-    project.publishing {
-        publications {
-            libs(MavenPublication) {
-                groupId = project.group
-                artifact project.tasks.distribution
-                pom {
-                    name = "LabKey Server SAS Client API"
-                    description = "Library of macros for use in accessing LabKey Server via SAS"
-                    url = PomFileHelper.LABKEY_ORG_URL
-                    developers PomFileHelper.getLabKeyTeamDevelopers()
-                    licenses PomFileHelper.getApacheLicense()
-                    organization PomFileHelper.getLabKeyOrganization()
-                    scm {
-                        connection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
-                        developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
-                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
-                    }
+project.publishing {
+    publications {
+        libs(MavenPublication) {
+            groupId = project.group
+            artifact project.tasks.distribution
+            pom {
+                name = "LabKey Server SAS Client API"
+                description = "Library of macros for use in accessing LabKey Server via SAS"
+                url = PomFileHelper.LABKEY_ORG_URL
+                developers PomFileHelper.getLabKeyTeamDevelopers()
+                licenses PomFileHelper.getApacheLicense()
+                organization PomFileHelper.getLabKeyOrganization()
+                scm {
+                    connection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
+                    developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
+                    url = 'scm:git:https://github.com/LabKey/labkey-api-java/sas'
                 }
-            }
-        }
-
-        if (project.hasProperty('doClientApiPublishing'))
-        {
-            apply plugin: 'com.jfrog.artifactory'
-            artifactory {
-                contextUrl = "${artifactory_contextUrl}"   //The base Artifactory URL if not overridden by the publisher/resolver
-                publish {
-                    repository {
-                        repoKey = BuildUtils.getRepositoryKey(project)
-                        if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
-                        {
-                            username = artifactory_user
-                            password = artifactory_password
-                        }
-                        maven = true
-                    }
-                    defaults
-                            {
-                                publishPom = true
-                                publishIvy = false
-                            }
-                }
-            }
-
-            project.artifactoryPublish {
-                publications('libs')
             }
         }
     }
-    project.model {
-        tasks.publishLibsPublicationToMavenLocal {
-            enabled = false
+    repositories {
+        maven {
+            url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
+            credentials {
+                username = artifactory_user
+                password = artifactory_password
+            }
+            authentication {
+                basic(BasicAuthentication)
+                // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
+            }
         }
     }
 }
+
+project.model {
+    tasks.publishLibsPublicationToMavenLocal {
+        enabled = false
+    }
+}
+

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -5,7 +5,7 @@ import org.labkey.gradle.plugin.extension.TeamCityExtension
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "${artifactory_contextUrl}/plugins-release"
         }

--- a/labkey-api-sas/gradle/wrapper/gradle-wrapper.properties
+++ b/labkey-api-sas/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -150,57 +150,57 @@ project.artifacts {
 
 def libDescription = "The client-side library for Java developers is a separate JAR from the LabKey Server code base. It can be used by any Java program, including another Java web application."
 
-if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
-{
-    project.publishing {
-        publications {
-            libs(MavenPublication) {
-                groupId = project.group
-                from components.java
-                artifact(sourcesJar) {
-                    classifier = LabKey.SOURCES_CLASSIFIER
+project.publishing {
+    publications {
+        libs(MavenPublication) {
+            groupId = project.group
+            from components.java
+            artifact(sourcesJar) {
+                classifier = LabKey.SOURCES_CLASSIFIER
+            }
+            artifact(javadocJar) {
+                classifier = LabKey.JAVADOC_CLASSIFIER
+            }
+            artifact(fatJar) {
+                classifier = LabKey.FAT_JAR_CLASSIFIER
+            }
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
                 }
-                artifact(javadocJar) {
-                    classifier = LabKey.JAVADOC_CLASSIFIER
+                usage('java-runtime') {
+                    fromResolutionResult()
                 }
-                artifact(fatJar) {
-                    classifier = LabKey.FAT_JAR_CLASSIFIER
-                }
-                versionMapping {
-                    usage('java-api') {
-                        fromResolutionOf('runtimeClasspath')
-                    }
-                    usage('java-runtime') {
-                        fromResolutionResult()
-                    }
-                }
-                pom {
-                    name = "LabKey Server Java Client API"
-                    description = libDescription
-                    url = PomFileHelper.LABKEY_ORG_URL
-                    developers PomFileHelper.getLabKeyTeamDevelopers()
-                    licenses PomFileHelper.getApacheLicense()
-                    organization PomFileHelper.getLabKeyOrganization()
-                    scm {
-                        connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                        developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
-                    }
+            }
+            pom {
+                name = "LabKey Server Java Client API"
+                description = libDescription
+                url = PomFileHelper.LABKEY_ORG_URL
+                developers PomFileHelper.getLabKeyTeamDevelopers()
+                licenses PomFileHelper.getApacheLicense()
+                organization PomFileHelper.getLabKeyOrganization()
+                scm {
+                    connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
+                    developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
+                    url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
                 }
             }
         }
-        repositories {
-            if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
-            {
-                maven {
-                    url sonatype_staging_url
-                    credentials {
-                        username sonatype_username
-                        password sonatype_password
-                    }
+    }
+    repositories {
+        if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
+        {
+            maven {
+                url sonatype_staging_url
+                credentials {
+                    username sonatype_username
+                    password sonatype_password
                 }
             }
+        }
 
+        if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+        {
             maven {
                 url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
                 credentials {
@@ -213,45 +213,49 @@ if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
                 }
             }
         }
-        apply plugin: 'com.jfrog.artifactory'
-        artifactory {
-            contextUrl = "${artifactory_contextUrl}"
-            //The base Artifactory URL if not overridden by the publisher/resolver
-            publish {
-                repository {
-                    repoKey = BuildUtils.getRepositoryKey(project)
+    }
+    apply plugin: 'com.jfrog.artifactory'
+    artifactory {
+        contextUrl = "${artifactory_contextUrl}"
+        //The base Artifactory URL if not overridden by the publisher/resolver
+        publish {
+            repository {
+                repoKey = BuildUtils.getRepositoryKey(project)
+                if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+                {
                     username = artifactory_user
                     password = artifactory_password
-                    maven = true
                 }
-                defaults {
-                    publishPom = true
-                    publishIvy = false
-                }
+                maven = true
             }
-        }
-
-        project.artifactoryPublish {
-            project.tasks.each {
-                if (it instanceof Jar)
-                {
-                    dependsOn it
-                }
+            defaults {
+                publishPom = true
+                publishIvy = false
             }
-            publications('libs')
         }
     }
 
-    project.model {
-        tasks.publishLibsPublicationToMavenLocal {
-            enabled = false
+    project.artifactoryPublish {
+        project.tasks.each {
+            if (it instanceof Jar)
+            {
+                dependsOn it
+            }
         }
-    }
-
-    if (project.hasProperty("signing.keyId") && project.hasProperty("signing.password") || project.hasProperty("signing.secretKeyRingFile"))
-    {
-        signing {
-            sign publishing.publications.libs
-        }
+        publications('libs')
     }
 }
+
+project.model {
+    tasks.publishLibsPublicationToMavenLocal {
+        enabled = false
+    }
+}
+
+if (project.hasProperty("signing.keyId") && project.hasProperty("signing.password") || project.hasProperty("signing.secretKeyRingFile"))
+{
+    signing {
+        sign publishing.publications.libs
+    }
+}
+

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -5,7 +5,7 @@ import org.labkey.gradle.util.PomFileHelper
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "${artifactory_contextUrl}/plugins-release"
         }
@@ -37,7 +37,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     maven {
         url "${artifactory_contextUrl}/libs-release"
 

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -33,7 +33,7 @@ plugins {
     id 'java-library'
     id 'java'
     id 'maven-publish'
-    id "com.jfrog.bintray" version "${bintrayPluginVersion}" apply false
+    id 'signing'
 }
 
 repositories {
@@ -53,9 +53,6 @@ repositories {
         }
     }
 }
-
-// TODO remove this and use default once client-api distribution doesn't need it
-buildDir = new File(project.rootProject.buildDir, "/remoteapi/labkey-api-java")
 
 group "org.labkey.api"
 
@@ -112,13 +109,13 @@ project.task("fatJar",
             Jar jar ->
                 jar.from sourceSets.main.output
                 jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-                jar.from { configurations.default.collect { it.isDirectory() ? it : zipTree(it) }}
+                jar.from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }}
                 jar.setArchiveVersion(project.version)
-                jar.classifier LabKey.FAT_JAR_CLASSIFIER
+                jar.archiveClassifier.set(LabKey.FAT_JAR_CLASSIFIER)
                 jar.dependsOn project.tasks.jar
                 jar.into('lib') {
                     from tasks.jar
-                    from configurations.default
+                    from configurations.runtimeClasspath
                 }
         }
 )
@@ -141,9 +138,8 @@ project.task('javadocJar', description: "Generate jar file of javadoc files", ty
 
 project.task('sourcesJar', description: "Generate jar file of source files", type: Jar) {Jar jar ->
             jar.from project.sourceSets.main.allJava
-
             jar.group GroupNames.DISTRIBUTION
-            jar.classifier LabKey.SOURCES_CLASSIFIER
+            jar.archiveClassifier.set(LabKey.SOURCES_CLASSIFIER)
 }
 
 project.artifacts {
@@ -154,125 +150,100 @@ project.artifacts {
 
 def libDescription = "The client-side library for Java developers is a separate JAR from the LabKey Server code base. It can be used by any Java program, including another Java web application."
 
-project.afterEvaluate {
-    project.publishing {
-        publications {
-            libs(MavenPublication) {
-                groupId = project.group
-                from components.java
-                versionMapping {
-                    usage('java-api') {
-                        fromResolutionOf('runtimeClasspath')
-                    }
-                    usage('java-runtime') {
-                        fromResolutionResult()
-                    }
+project.publishing {
+    publications {
+        libs(MavenPublication) {
+            groupId = project.group
+            from components.java
+            artifact(jar)
+            artifact(sourcesJar) {
+                classifier = LabKey.SOURCES_CLASSIFIER
+            }
+            artifact(javadocJar) {
+                classifier = LabKey.JAVADOC_CLASSIFIER
+            }
+            artifact(fatJar) {
+                classifier = LabKey.FAT_JAR_CLASSIFIER
+            }
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
                 }
-                pom {
-                    name = "LabKey Server Java Client API"
-                    description = libDescription
-                    url = PomFileHelper.LABKEY_ORG_URL
-                    developers PomFileHelper.getLabKeyTeamDevelopers()
-                    licenses PomFileHelper.getApacheLicense()
-                    organization PomFileHelper.getLabKeyOrganization()
-                    scm {
-                        connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                        developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
-                    }
+                usage('java-runtime') {
+                    fromResolutionResult()
                 }
-
-                project.tasks.each {
-                    if (it instanceof Jar)
-                    {
-                        artifact it
-                    }
+            }
+            pom {
+                name = "LabKey Server Java Client API"
+                description = libDescription
+                url = PomFileHelper.LABKEY_ORG_URL
+                developers PomFileHelper.getLabKeyTeamDevelopers()
+                licenses PomFileHelper.getApacheLicense()
+                organization PomFileHelper.getLabKeyOrganization()
+                scm {
+                    connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
+                    developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
+                    url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
                 }
             }
         }
-
-        if (project.hasProperty('doClientApiPublishing'))
-        {
-            apply plugin: 'com.jfrog.artifactory'
-            artifactory {
-                contextUrl = "${artifactory_contextUrl}"   //The base Artifactory URL if not overridden by the publisher/resolver
-                publish {
-                    repository {
-                        repoKey = BuildUtils.getRepositoryKey(project)
-                        if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
-                        {
-                            username = artifactory_user
-                            password = artifactory_password
-                        }
-                        maven = true
-                    }
-                    defaults
-                            {
-                                publishPom = true
-                                publishIvy = false
-                            }
-                }
-            }
-
-            project.artifactoryPublish {
-                project.tasks.each {
-                    if (it instanceof Jar)
-                    {
-                        dependsOn it
-                    }
-                }
-                publications('libs')
-            }
-        }
-
     }
-    project.model {
-        tasks.publishLibsPublicationToMavenLocal {
-            enabled = false
+    if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
+    {
+        repositories {
+            maven {
+                url sonatype_staging_url
+                credentials {
+                    username sonatype_username
+                    password sonatype_password
+                }
+            }
         }
+    }
+
+    apply plugin: 'com.jfrog.artifactory'
+    artifactory {
+        contextUrl = "${artifactory_contextUrl}"
+        //The base Artifactory URL if not overridden by the publisher/resolver
+        publish {
+            repository {
+                repoKey = BuildUtils.getRepositoryKey(project)
+                if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+                {
+                    username = artifactory_user
+                    password = artifactory_password
+                }
+                maven = true
+            }
+            defaults
+                    {
+                        publishPom = true
+                        publishIvy = false
+                    }
+        }
+    }
+
+    project.artifactoryPublish {
+        project.tasks.each {
+            if (it instanceof Jar)
+            {
+                dependsOn it
+            }
+        }
+        publications('libs')
     }
 }
 
-// This section is used for publishing the jar files to bintray and then on to maven central.
-if (project.hasProperty('bintray_user')
-        && project.hasProperty('bintray_api_key')
-        && project.hasProperty('gpg_passphrase')
-        && project.hasProperty('sonatype_username')
-        && project.hasProperty('sonatype_password'))
-{
-    apply plugin: 'com.jfrog.bintray'
-    bintray {
-        user = project.bintray_user
-        key = project.bintray_api_key
-        publications = ['libs']
-        publish = true
-        pkg {
-            repo = project.version.endsWith('SNAPSHOT') ? 'libs-snapshot' : 'libs-release'
-            desc = libDescription
-            websiteUrl = PomFileHelper.LABKEY_ORG_URL
-            name = project.name
-            userOrg = 'labkey'
-            licenses = ['Apache-2.0']
-            vcsUrl = 'https://github.com/LabKey/labkey-api-java'
-            version {
-                name = project.version
-                desc = "LabKey Java Client API ${project.version}"
-                released = new Date()
-                gpg {
-                    sign = true
-                    passphrase = project.gpg_passphrase
-                }
+project.model {
+    tasks.publishLibsPublicationToMavenLocal {
+        enabled = false
+    }
+}
 
-                mavenCentralSync {
-                    sync = true //[Default: true] Determines whether to sync the version to Maven Central.
-                    user = project.sonatype_username //OSS user token: mandatory
-                    password = project.sonatype_password //OSS user password: mandatory
-                    close = '1'
-                    //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. 
-                    //You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
-                }
-            }
-        }
+if (project.hasProperty("signing.keyId") && project.hasProperty("signing.password") || project.hasProperty("signing.secretKeyRingFile"))
+{
+    signing {
+        sign publishing.publications.libs
     }
 }
 

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -141,78 +141,81 @@ project.artifacts {
 
 def libDescription = "The client-side library for Java developers is a separate JAR from the LabKey Server code base. It can be used by any Java program, including another Java web application."
 
-project.publishing {
-    publications {
-        libs(MavenPublication) {
-            groupId = project.group
-            from components.java
-            artifact(sourcesJar) {
-                classifier = LabKey.SOURCES_CLASSIFIER
-            }
-            artifact(javadocJar) {
-                classifier = LabKey.JAVADOC_CLASSIFIER
-            }
-            artifact(fatJar) {
-                classifier = LabKey.FAT_JAR_CLASSIFIER
-            }
-            versionMapping {
-                usage('java-api') {
-                    fromResolutionOf('runtimeClasspath')
-                }
-                usage('java-runtime') {
-                    fromResolutionResult()
-                }
-            }
-            pom {
-                name = "LabKey Server Java Client API"
-                description = libDescription
-                url = PomFileHelper.LABKEY_ORG_URL
-                developers PomFileHelper.getLabKeyTeamDevelopers()
-                licenses PomFileHelper.getApacheLicense()
-                organization PomFileHelper.getLabKeyOrganization()
-                scm {
-                    connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                    developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
-                    url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
-                }
-            }
-        }
-    }
-    repositories {
-        if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
-        {
-            maven {
-                url sonatype_staging_url
-                credentials {
-                    username sonatype_username
-                    password sonatype_password
-                }
-            }
-        }
-
-        maven {
-            url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
-            credentials {
-                username = artifactory_user
-                password = artifactory_password
-            }
-            authentication {
-                basic(BasicAuthentication)
-                // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
-            }
-        }
-    }
-}
-
-project.model {
-    tasks.publishLibsPublicationToMavenLocal {
-        enabled = false
-    }
-}
-
-if (project.hasProperty("signing.keyId") && project.hasProperty("signing.password") || project.hasProperty("signing.secretKeyRingFile"))
+if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
 {
-    signing {
-        sign publishing.publications.libs
+    project.publishing {
+        publications {
+            libs(MavenPublication) {
+                groupId = project.group
+                from components.java
+                artifact(sourcesJar) {
+                    classifier = LabKey.SOURCES_CLASSIFIER
+                }
+                artifact(javadocJar) {
+                    classifier = LabKey.JAVADOC_CLASSIFIER
+                }
+                artifact(fatJar) {
+                    classifier = LabKey.FAT_JAR_CLASSIFIER
+                }
+                versionMapping {
+                    usage('java-api') {
+                        fromResolutionOf('runtimeClasspath')
+                    }
+                    usage('java-runtime') {
+                        fromResolutionResult()
+                    }
+                }
+                pom {
+                    name = "LabKey Server Java Client API"
+                    description = libDescription
+                    url = PomFileHelper.LABKEY_ORG_URL
+                    developers PomFileHelper.getLabKeyTeamDevelopers()
+                    licenses PomFileHelper.getApacheLicense()
+                    organization PomFileHelper.getLabKeyOrganization()
+                    scm {
+                        connection = 'scm:git:https://github.com/LabKey/labkey-api-java'
+                        developerConnection = 'scm:git:https://github.com/LabKey/labkey-api-java'
+                        url = 'scm:git:https://github.com/LabKey/labkey-api-java/labkey-client-api'
+                    }
+                }
+            }
+        }
+        repositories {
+            if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
+            {
+                maven {
+                    url sonatype_staging_url
+                    credentials {
+                        username sonatype_username
+                        password sonatype_password
+                    }
+                }
+            }
+
+            maven {
+                url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
+                credentials {
+                    username = artifactory_user
+                    password = artifactory_password
+                }
+                authentication {
+                    basic(BasicAuthentication)
+                    // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
+                }
+            }
+        }
+    }
+
+    project.model {
+        tasks.publishLibsPublicationToMavenLocal {
+            enabled = false
+        }
+    }
+
+    if (project.hasProperty("signing.keyId") && project.hasProperty("signing.password") || project.hasProperty("signing.secretKeyRingFile"))
+    {
+        signing {
+            sign publishing.publications.libs
+        }
     }
 }

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.plugin.LabKey
+import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
 
@@ -17,6 +18,14 @@ buildscript {
     }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
+        // N.B.  We use the "old-fashioned" way of applying the artifactory plugin because if we use
+        // the plugins block below and specify a version number, the following error happens if building
+        // in conjunction with LabKey server (i.e., when including this project in the server's build.gradle
+        //    Error resolving plugin [id: 'com.jfrog.artifactory', version: '4.13.0', apply: false]
+        //    > Plugin request for plugin already on the classpath must not include a version
+        // We could instead include the plugin without a version number, which would work until
+        // some change in the latest version of the plugin came along that we aren't compatible with.
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:${artifactoryPluginVersion}"
     }
 }
 
@@ -203,6 +212,33 @@ if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
                     // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
                 }
             }
+        }
+        apply plugin: 'com.jfrog.artifactory'
+        artifactory {
+            contextUrl = "${artifactory_contextUrl}"
+            //The base Artifactory URL if not overridden by the publisher/resolver
+            publish {
+                repository {
+                    repoKey = BuildUtils.getRepositoryKey(project)
+                    username = artifactory_user
+                    password = artifactory_password
+                    maven = true
+                }
+                defaults {
+                    publishPom = true
+                    publishIvy = false
+                }
+            }
+        }
+
+        project.artifactoryPublish {
+            project.tasks.each {
+                if (it instanceof Jar)
+                {
+                    dependsOn it
+                }
+            }
+            publications('libs')
         }
     }
 

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -1,5 +1,4 @@
 import org.labkey.gradle.plugin.LabKey
-import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
 
@@ -18,14 +17,6 @@ buildscript {
     }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-        // N.B.  We use the "old-fashioned" way of applying the artifactory plugin because if we use
-        // the plugins block below and specify a version number, the following error happens if building
-        // in conjunction with LabKey server (i.e., when including this project in the server's build.gradle
-        //    Error resolving plugin [id: 'com.jfrog.artifactory', version: '4.13.0', apply: false]
-        //    > Plugin request for plugin already on the classpath must not include a version
-        // We could instead include the plugin without a version number, which would work until
-        // some change in the latest version of the plugin came along that we aren't compatible with.
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:${artifactoryPluginVersion}"
     }
 }
 
@@ -155,7 +146,6 @@ project.publishing {
         libs(MavenPublication) {
             groupId = project.group
             from components.java
-            artifact(jar)
             artifact(sourcesJar) {
                 classifier = LabKey.SOURCES_CLASSIFIER
             }
@@ -188,9 +178,9 @@ project.publishing {
             }
         }
     }
-    if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
-    {
-        repositories {
+    repositories {
+        if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
+        {
             maven {
                 url sonatype_staging_url
                 credentials {
@@ -199,38 +189,18 @@ project.publishing {
                 }
             }
         }
-    }
 
-    apply plugin: 'com.jfrog.artifactory'
-    artifactory {
-        contextUrl = "${artifactory_contextUrl}"
-        //The base Artifactory URL if not overridden by the publisher/resolver
-        publish {
-            repository {
-                repoKey = BuildUtils.getRepositoryKey(project)
-                if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
-                {
-                    username = artifactory_user
-                    password = artifactory_password
-                }
-                maven = true
+        maven {
+            url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
+            credentials {
+                username = artifactory_user
+                password = artifactory_password
             }
-            defaults
-                    {
-                        publishPom = true
-                        publishIvy = false
-                    }
-        }
-    }
-
-    project.artifactoryPublish {
-        project.tasks.each {
-            if (it instanceof Jar)
-            {
-                dependsOn it
+            authentication {
+                basic(BasicAuthentication)
+                // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
             }
         }
-        publications('libs')
     }
 }
 
@@ -246,4 +216,3 @@ if (project.hasProperty("signing.keyId") && project.hasProperty("signing.passwor
         sign publishing.publications.libs
     }
 }
-

--- a/labkey-client-api/gradle/wrapper/gradle-wrapper.properties
+++ b/labkey-client-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Rationale
Jcenter is being sunsetted by jfrog in May of this year, so we need to go back to publishing artifacts to Maven Central through sonatype. 

[Internal documentation](https://internal.labkey.com/Handbook/Dev/wiki-page.view?name=mavenArtifacts) has been updated to reflect these changes.

#### Related Pull Requests
* https://github.com/LabKey/test_secure/pull/4

#### Changes
* replace jcenter() with mavenCentral()
* remove use of artifactory publishing plugin
* remove use of specialized build directories since these artifacts are no longer needed for the client API distrbution
