### PR TITLE
Don't modify signature of 'Connection' constructor.

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,8 +1,14 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version TBD
+*Released*: TBD
+* [Issue 43380](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43380): ImportDataCommand missing options supported by query-import.api
+* Remove `CheckForStudyReloadCommand.java`
+* Remove `URISyntaxException` from one `Connection` constructor
+
 ## version 1.4.0
 *Released*: 16 June 2021
-* Issue 43246: Lineage query NPE while processing an UploadedFile
+* [Issue 43246](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43246): Lineage query NPE while processing an UploadedFile
 * Additional lineage options and support additional properties in response
 * Update dependency version numbers
 * Update to Gradle 7.1

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -142,7 +142,7 @@ public class Connection
     {
         if (baseURI.getHost() == null || baseURI.getScheme() == null)
         {
-            throw new IllegalArgumentException("Invalid server URL: " + baseURI.toString());
+            throw new IllegalArgumentException("Invalid server URL: " + baseURI);
         }
         _baseURI = baseURI;
         _credentialsProvider = credentialsProvider;
@@ -173,14 +173,13 @@ public class Connection
      * Constructs a new Connection object with a base URL that attempts authentication via .netrc/_netrc entry, if present.
      * If not present, connects as guest.
      * @param baseUrl The base URL
-     * @throws URISyntaxException if the given url is not a valid URI
      * @throws IOException if there are problems reading the credentials
      * @see NetrcCredentialsProvider
      * @see #Connection(URI, CredentialsProvider)
      */
-    public Connection(String baseUrl) throws URISyntaxException, IOException
+    public Connection(String baseUrl) throws IOException
     {
-        this(new URI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
+        this(toURI(baseUrl), new NetrcCredentialsProvider(toURI(baseUrl)));
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -173,13 +173,14 @@ public class Connection
      * Constructs a new Connection object with a base URL that attempts authentication via .netrc/_netrc entry, if present.
      * If not present, connects as guest.
      * @param baseUrl The base URL
+     * @throws URISyntaxException if the given url is not a valid URI
      * @throws IOException if there are problems reading the credentials
      * @see NetrcCredentialsProvider
      * @see #Connection(URI, CredentialsProvider)
      */
-    public Connection(String baseUrl) throws IOException
+    public Connection(String baseUrl) throws URISyntaxException, IOException
     {
-        this(toURI(baseUrl), new NetrcCredentialsProvider(toURI(baseUrl)));
+        this(new URI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -297,7 +298,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
         return new ImportDataCommand(this);
     }
 
-    public static void main(String[] args) throws IOException
+    public static void main(String[] args) throws IOException, URISyntaxException
     {
         // required
         String baseServerUrl = null;

--- a/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
@@ -32,7 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -298,7 +298,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
         return new ImportDataCommand(this);
     }
 
-    public static void main(String[] args) throws IOException, URISyntaxException
+    public static void main(String[] args) throws IOException
     {
         // required
         String baseServerUrl = null;
@@ -581,7 +581,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
     private static String readFully(InputStream in) throws IOException
     {
         StringWriter sw = new StringWriter();
-        try (BufferedReader buf = new BufferedReader(new InputStreamReader(in)))
+        try (BufferedReader buf = new BufferedReader(new InputStreamReader(in, Charset.defaultCharset())))
         {
             String line;
             do


### PR DESCRIPTION
#### Rationale
A previous update changed the signature of one of the 'Connection' constructors. This broke compatibility with some usages that were catching the `URISyntaxException` it claimed to throw.
This makes the constructors inconsistent but fixing those up is a job for another day.

#### Related Pull Requests
* #22 
* https://github.com/LabKey/labkey-api-jdbc/pull/17

#### Changes
* Make 'Connection' constructor match signature from v1.4.0
