### PR TITLE
Gradle version 7.4.2 and update build.gradle to reference mavenCentral explicitly

### DIFF
--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -6,6 +6,7 @@ import org.labkey.gradle.plugin.extension.TeamCityExtension
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-mc"
         }

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-mc"
+            url "${artifactory_contextUrl}/plugins-release"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -29,7 +29,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url "${artifactory_contextUrl}/libs-release-no-mc"
+        url "${artifactory_contextUrl}/libs-release"
 
         if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
         {

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-mc"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -6,7 +6,6 @@ import org.labkey.gradle.plugin.extension.TeamCityExtension
 buildscript {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-mc"
         }

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -27,8 +27,9 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     maven {
-        url "${artifactory_contextUrl}/libs-release"
+        url "${artifactory_contextUrl}/libs-release-no-mc"
 
         if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
         {

--- a/labkey-api-sas/gradle.properties
+++ b/labkey-api-sas/gradle.properties
@@ -3,6 +3,6 @@
 # in the context URL or you will get a 500 error from artifactory.)
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
-artifactoryPluginVersion=4.13.0
-gradlePluginsVersion=1.12.0
-labkeyClientApiVersion=1.2.0
+artifactoryPluginVersion=4.21.0
+gradlePluginsVersion=1.32.2
+labkeyClientApiVersion=1.4.0

--- a/labkey-api-sas/gradle/wrapper/gradle-wrapper.properties
+++ b/labkey-api-sas/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,8 +1,14 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version TBD
+*Released*: TBD
+* [Issue 43380](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43380): ImportDataCommand missing options supported by query-import.api
+* Remove `CheckForStudyReloadCommand.java`
+* Remove `URISyntaxException` from one `Connection` constructor
+
 ## version 1.4.0
 *Released*: 16 June 2021
-* Issue 43246: Lineage query NPE while processing an UploadedFile
+* [Issue 43246](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43246): Lineage query NPE while processing an UploadedFile
 * Additional lineage options and support additional properties in response
 * Update dependency version numbers
 * Update to Gradle 7.1

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version TBD
-*Released*: TBD
+## version 1.5.0
+*Released*: 20 April 2022
 * Update gradle and various dependencies
 * Update signature of `Connection` constructor
 * [Issue 43380](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43380): `ImportDataCommand` missing options supported by the query-import.api endpoint

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version TBD
+*Released*: TBD
+* Update gradle and various dependencies
+* Update signature of `Connection` constructor
+* Issue 43380: `ImportDataCommand` missing options supported by the query-import.api endpoint
+* Remove `CheckForStudyReloadCommand`.
+
 ## version 1.4.0
 *Released*: 16 June 2021
 * Issue 43246: Lineage query NPE while processing an UploadedFile

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.5.0-SNAPSHOT"
+version "1.5.0"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-mc"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -37,8 +37,9 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     maven {
-        url "${artifactory_contextUrl}/libs-release"
+        url "${artifactory_contextUrl}/libs-release-no-mc"
 
         if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
         {

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.5.0"
+version "1.6.0-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -241,6 +241,7 @@ project.publishing {
                 maven = true
             }
             defaults {
+                publishBuildInfo = false
                 publishPom = true
                 publishIvy = false
             }

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-mc"
+            url "${artifactory_contextUrl}/plugins-release"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -39,7 +39,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url "${artifactory_contextUrl}/libs-release-no-mc"
+        url "${artifactory_contextUrl}/libs-release"
 
         if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
         {

--- a/labkey-client-api/gradle.properties
+++ b/labkey-client-api/gradle.properties
@@ -11,7 +11,7 @@ sourceCompatibility=1.8
 targetCompatibility=1.8
 
 artifactoryPluginVersion=4.21.0
-gradlePluginsVersion=1.26.0
+gradlePluginsVersion=1.32.2
 
 commonsCodecVersion=1.15
 commonsLoggingVersion=1.2

--- a/labkey-client-api/gradle/wrapper/gradle-wrapper.properties
+++ b/labkey-client-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -142,7 +142,7 @@ public class Connection
     {
         if (baseURI.getHost() == null || baseURI.getScheme() == null)
         {
-            throw new IllegalArgumentException("Invalid server URL: " + baseURI.toString());
+            throw new IllegalArgumentException("Invalid server URL: " + baseURI);
         }
         _baseURI = baseURI;
         _credentialsProvider = credentialsProvider;
@@ -173,14 +173,13 @@ public class Connection
      * Constructs a new Connection object with a base URL that attempts authentication via .netrc/_netrc entry, if present.
      * If not present, connects as guest.
      * @param baseUrl The base URL
-     * @throws URISyntaxException if the given url is not a valid URI
      * @throws IOException if there are problems reading the credentials
      * @see NetrcCredentialsProvider
      * @see #Connection(URI, CredentialsProvider)
      */
-    public Connection(String baseUrl) throws URISyntaxException, IOException
+    public Connection(String baseUrl) throws IOException
     {
-        this(new URI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
+        this(toURI(baseUrl), new NetrcCredentialsProvider(toURI(baseUrl)));
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -173,13 +173,14 @@ public class Connection
      * Constructs a new Connection object with a base URL that attempts authentication via .netrc/_netrc entry, if present.
      * If not present, connects as guest.
      * @param baseUrl The base URL
+     * @throws URISyntaxException if the given url is not a valid URI
      * @throws IOException if there are problems reading the credentials
      * @see NetrcCredentialsProvider
      * @see #Connection(URI, CredentialsProvider)
      */
-    public Connection(String baseUrl) throws IOException
+    public Connection(String baseUrl) throws URISyntaxException, IOException
     {
-        this(toURI(baseUrl), new NetrcCredentialsProvider(toURI(baseUrl)));
+        this(new URI(baseUrl), new NetrcCredentialsProvider(new URI(baseUrl)));
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -297,7 +298,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
         return new ImportDataCommand(this);
     }
 
-    public static void main(String[] args) throws IOException
+    public static void main(String[] args) throws IOException, URISyntaxException
     {
         // required
         String baseServerUrl = null;

--- a/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
@@ -32,7 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -298,7 +298,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
         return new ImportDataCommand(this);
     }
 
-    public static void main(String[] args) throws IOException, URISyntaxException
+    public static void main(String[] args) throws IOException
     {
         // required
         String baseServerUrl = null;
@@ -581,7 +581,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
     private static String readFully(InputStream in) throws IOException
     {
         StringWriter sw = new StringWriter();
-        try (BufferedReader buf = new BufferedReader(new InputStreamReader(in)))
+        try (BufferedReader buf = new BufferedReader(new InputStreamReader(in, Charset.defaultCharset())))
         {
             String line;
             do


### PR DESCRIPTION
#### Rationale
We plan to update our Artifactory configuration so it no longer proxies for certain remote repositories. This requires that builds that require these remote repositories declare these repositories themselves.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/234

#### Changes
* Update to latest versions of various dependencies
* Update to Gradle v7.4.2
* Stop publishing `buildInfo`
* Declare `mavenCentral` repository as first repository
