### PR TITLE
Fix NPE when saving assay protocol with transform scripts

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version 1.5.1
+*Released*: TBD
+* Fix NPE when saving assay protocol with transform scripts
+
 ## version 1.5.0
 *Released*: 20 April 2022
 * Update gradle and various dependencies

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.6.0-SNAPSHOT"
+version "1.5.1-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/Protocol.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/Protocol.java
@@ -40,7 +40,7 @@ public class Protocol extends ResponseObject
     private Map<String, String> _availableMetadataInputFormats;
     private String _selectedMetadataInputFormat;
 
-    private List<String> _availablePlateTemplates = new ArrayList<>();
+    private List<String> _availablePlateTemplates;
     private String _selectedPlateTemplate;
 
     private Map<String, String> _protocolParameters;
@@ -90,31 +90,22 @@ public class Protocol extends ResponseObject
             _autoCopyTargetContainerId = (String)json.get("autoCopyTargetContainerId");
 
         if (json.get("availableDetectionMethods") instanceof JSONArray)
-        {
-            for (Object detectionMethod : (JSONArray)json.get("availableDetectionMethods"))
-                _availableDetectionMethods.add((String)detectionMethod);
-        }
+            _availableDetectionMethods = new ArrayList<>((JSONArray)json.get("availableDetectionMethods"));
         if (json.containsKey("selectedDetectionMethod"))
             _selectedDetectionMethod = (String)json.get("selectedDetectionMethod");
-        if (json.containsKey("availableMetadataInputFormats"))
-            _availableMetadataInputFormats = (HashMap<String,String>)json.get("availableMetadataInputFormats");
+        if (json.get("availableMetadataInputFormats") instanceof JSONObject)
+            _availableMetadataInputFormats = new HashMap<>((JSONObject)json.get("availableMetadataInputFormats"));
         if (json.containsKey("selectedMetadataInputFormat"))
             _selectedMetadataInputFormat = (String)json.get("selectedMetadataInputFormat");
         if (json.get("availablePlateTemplates") instanceof JSONArray)
-        {
-            for (Object plateTemplate : (JSONArray)json.get("availablePlateTemplates"))
-                _availablePlateTemplates.add((String)plateTemplate);
-        }
+            _availablePlateTemplates = new ArrayList<>((JSONArray)json.get("availablePlateTemplates"));
         if (json.containsKey("selectedPlateTemplate"))
             _selectedPlateTemplate = (String)json.get("selectedPlateTemplate");
 
-        if (json.get("protocolTransformScripts") instanceof JSONArray)
-        {
-            for (Object transformScript : (JSONArray)json.get("protocolTransformScripts"))
-                _protocolTransformScripts.add((String)transformScript);
-        }
+        if (json.containsKey("protocolTransformScripts"))
+            _protocolTransformScripts = new ArrayList<>((JSONArray)json.get("protocolTransformScripts"));
         if (json.containsKey("protocolParameters"))
-            _protocolParameters = (HashMap<String,String>)json.get("protocolParameters");
+            _protocolParameters = new HashMap<>((JSONObject) json.get("protocolParameters"));
     }
 
     public JSONObject toJSONObject()
@@ -316,6 +307,11 @@ public class Protocol extends ResponseObject
     public String getSelectedDetectionMethod()
     {
         return _selectedDetectionMethod;
+    }
+
+    public Map<String, String> getAvailableMetadataInputFormats()
+    {
+        return _availableMetadataInputFormats;
     }
 
     public Protocol setSelectedMetadataInputFormat(String inputFormat)


### PR DESCRIPTION
#### Rationale
Trying to refactor a test to create an assay via API. The assay has a transform script, which caused an NPE when attempting to construct the response object.
```
java.lang.NullPointerException: Cannot invoke "java.util.List.add(Object)" because "this._protocolTransformScripts" is null
	at org.labkey.remoteapi.assay.Protocol.<init>(Protocol.java:114)
	at org.labkey.remoteapi.assay.ProtocolResponse.<init>(ProtocolResponse.java:13)
	at org.labkey.remoteapi.assay.SaveProtocolCommand.createResponse(SaveProtocolCommand.java:19)
	at org.labkey.remoteapi.assay.SaveProtocolCommand.createResponse(SaveProtocolCommand.java:6)
	at org.labkey.remoteapi.Command.execute(Command.java:232)
```

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Fix NPE in Protocol constructor
