### PR TITLE
Support DerivationDataScope domain property

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version XX
+*Released* : XX
+* Add derivationDataScope to PropertyDescriptor
+
 ## version 1.5.0
 *Released*: 20 April 2022
 * Update gradle and various dependencies

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for Java - Change Log
 
 ## version 1.5.1
-*Released*: XX July 2022
+*Released*: 7 July 2022
 * Fix NPE when saving assay protocol with transform scripts
 * Add derivationDataScope to PropertyDescriptor
 

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,12 +1,9 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version XX
-*Released* : XX
-* Add derivationDataScope to PropertyDescriptor
-
 ## version 1.5.1
-*Released*: 5 July 2022
+*Released*: XX July 2022
 * Fix NPE when saving assay protocol with transform scripts
+* Add derivationDataScope to PropertyDescriptor
 
 ## version 1.5.0
 *Released*: 20 April 2022

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.6.0-SNAPSHOT"
+version "1.5.1-fb-aliquotOptions-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.5.2-fb-aliquotOptions-SNAPSHOT"
+version "1.6.0-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/src/org/labkey/remoteapi/domain/PropertyDescriptor.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/domain/PropertyDescriptor.java
@@ -26,6 +26,7 @@ public class PropertyDescriptor extends ResponseObject
     private String _lookupSchema;
     private String _lookupQuery;
     private String _lookupContainer;
+    private String _derivationDataScope;
     private List<ConditionalFormat> _conditionalFormats = new ArrayList<>();
 
     public PropertyDescriptor()
@@ -85,6 +86,8 @@ public class PropertyDescriptor extends ResponseObject
             _lookupQuery = (String)json.get("lookupQuery");
         if (json.get("lookupContainer") != null)
             _lookupContainer = (String)json.get("lookupContainer");
+        if (json.get("derivationDataScope") != null)
+            _derivationDataScope = (String)json.get("derivationDataScope");
         if (json.get("mvEnabled") != null)
             _mvEnabled = (Boolean)json.get("mvEnabled");
     }
@@ -114,6 +117,9 @@ public class PropertyDescriptor extends ResponseObject
         result.put("dimension", _dimension);
         result.put("propertyURI", _propertyURI);
         result.put("conditionalFormats", serializeConditionalFormats());
+
+        if (_derivationDataScope != null)
+            result.put("derivationDataScope", _derivationDataScope);
 
         if (_rangeURI != null)
             result.put("rangeURI", _rangeURI);
@@ -314,4 +320,15 @@ public class PropertyDescriptor extends ResponseObject
     {
         return Collections.unmodifiableList(_conditionalFormats);
     }
+
+    public String getDerivationDataScope()
+    {
+        return _derivationDataScope;
+    }
+
+    public void setDerivationDataScope(String derivationDataScope)
+    {
+        _derivationDataScope = derivationDataScope;
+    }
+
 }


### PR DESCRIPTION
#### Rationale
Add DerivationDataScope to PropertyDescriptor so the sample type creation api can create aliquot-specific fields

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/28
* https://github.com/LabKey/server/pull/270
* https://github.com/LabKey/testAutomation/pull/1151
* https://github.com/LabKey/labkey-ui-components/pull/872
* https://github.com/LabKey/platform/pull/3472
* https://github.com/LabKey/sampleManagement/pull/1032
* https://github.com/LabKey/biologics/pull/1390

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
