### PR TITLE
Set user agent

### DIFF
--- a/labkey-api-sas/gradle.properties
+++ b/labkey-api-sas/gradle.properties
@@ -5,4 +5,4 @@ artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 artifactoryPluginVersion=4.21.0
 gradlePluginsVersion=1.32.2
-labkeyClientApiVersion=1.5.2-SNAPSHOT
+labkeyClientApiVersion=1.5.2

--- a/labkey-api-sas/gradle.properties
+++ b/labkey-api-sas/gradle.properties
@@ -5,4 +5,4 @@ artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 artifactoryPluginVersion=4.21.0
 gradlePluginsVersion=1.32.2
-labkeyClientApiVersion=1.4.0
+labkeyClientApiVersion=1.5.2-SNAPSHOT

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version x.y.z
+*Released*: ??
+* Add Connection.setUserAgent() and Connection.getUserAgent()
+* Set Java library user agent to "LabKey Java API"
+* Set SAS library user agent to "LabKey SAS API"
+
 ## version 1.5.1
 *Released*: 7 July 2022
 * Fix NPE when saving assay protocol with transform scripts

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version x.y.z
-*Released*: ??
+## version 1.5.2
+*Released*: 14 July 2022
 * Add Connection.setUserAgent() and Connection.getUserAgent()
 * Set Java library user agent to "LabKey Java API"
 * Set SAS library user agent to "LabKey SAS API"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.5.2-SNAPSHOT"
+version "1.6.0-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.6.0-SNAPSHOT"
+version "1.5.2-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -120,6 +120,7 @@ public class Connection
     // The user email when impersonating a user
     private String _impersonateUser;
     private String _impersonatePath;
+    private String _userAgent = "LabKey Java API";
 
     /**
      * Constructs a new Connection object given a base URL and a credentials provider.
@@ -261,6 +262,9 @@ public class Connection
                 throw new RuntimeException(e);
             }
         }
+
+        if (null != _userAgent)
+            builder.setUserAgent(_userAgent);
 
         return builder;
     }
@@ -489,6 +493,16 @@ public class Connection
         _acceptSelfSignedCerts = acceptSelfSignedCerts;
         _client = null;
         return this;
+    }
+
+    public String getUserAgent()
+    {
+        return _userAgent;
+    }
+
+    public void setUserAgent(String userAgent)
+    {
+        _userAgent = userAgent;
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/sas/SASConnection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/sas/SASConnection.java
@@ -18,6 +18,7 @@ package org.labkey.remoteapi.sas;
 import org.labkey.remoteapi.ApiKeyCredentialsProvider;
 import org.labkey.remoteapi.BasicAuthCredentialsProvider;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.CredentialsProvider;
 import org.labkey.remoteapi.NetrcCredentialsProvider;
 
 import java.io.IOException;
@@ -31,24 +32,30 @@ import java.net.URISyntaxException;
  */
 public class SASConnection extends Connection
 {
+    private SASConnection(String baseUrl, CredentialsProvider credentialsProvider)
+    {
+        super(baseUrl, credentialsProvider);
+        setUserAgent("LabKey SAS API");
+    }
+
     @SuppressWarnings({"UnusedDeclaration"})
     // Called from SAS macros via reflective JavaObj interface
-    public SASConnection(String baseUrl, String userName, String password) throws IOException, URISyntaxException
+    public SASConnection(String baseUrl, String userName, String password)
     {
-        super(baseUrl, new BasicAuthCredentialsProvider(userName, password));
+        this(baseUrl, new BasicAuthCredentialsProvider(userName, password));
     }
 
     @SuppressWarnings({"UnusedDeclaration"})
     // Called from SAS macros via reflective JavaObj interface
     public SASConnection(String baseUrl) throws IOException, URISyntaxException
     {
-        super(baseUrl, new NetrcCredentialsProvider(new URI(baseUrl)));
+        this(baseUrl, new NetrcCredentialsProvider(new URI(baseUrl)));
     }
 
     @SuppressWarnings({"UnusedDeclaration"})
     // Called from SAS macros via reflective JavaObj interface
-    public SASConnection(String baseUrl, String apiKey) throws IOException, URISyntaxException
+    public SASConnection(String baseUrl, String apiKey)
     {
-        super(baseUrl, new ApiKeyCredentialsProvider(apiKey));
+        this(baseUrl, new ApiKeyCredentialsProvider(apiKey));
     }
 }


### PR DESCRIPTION
#### Rationale
If our Java, SAS, and JDBC libraries sent unique user agent strings then LabKey Server would be able to distinguish between them for metrics purposes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3533

#### Changes
* Add `get/setUserAgent()` on `Connection`
* Use it