### PR TITLE
Update Artifactory URL

### DIFF
--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -47,7 +47,7 @@ repositories {
 
 group 'org.labkey.api'
 
-version '1.0.0-SNAPSHOT'
+version '1.0.0-artifactorySaaS-SNAPSHOT'
 
 // We add the TeamCity extension here if it doesn't exist because we will use the build
 // number property from TeamCity in the distribution artifact names, if present.

--- a/labkey-api-sas/gradle.properties
+++ b/labkey-api-sas/gradle.properties
@@ -1,7 +1,7 @@
 # the URL for the artifact repository where our build plugins are housed
 # as well as the build artifacts. (Be careful not to include a trailing slash
 # in the context URL or you will get a 500 error from artifactory.)
-artifactory_contextUrl=https://artifactory.labkey.com/artifactory
+artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 artifactoryPluginVersion=4.21.0
 gradlePluginsVersion=1.32.2

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.6.0-SNAPSHOT"
+version "1.6.0-artifactorySaas-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/gradle.properties
+++ b/labkey-client-api/gradle.properties
@@ -1,7 +1,7 @@
 # the URL for the artifact repository where our build plugins are housed
 # as well as the build artifacts. (Be careful not to include a trailing slash
 # in the context URL or you will get a 500 error from artifactory.)
-artifactory_contextUrl=https://artifactory.labkey.com/artifactory
+artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # The source and target versions of Java for compilation tasks
 # We target a very old version to stay compatible with SAS. Our SAS macros wrap the Java remoteapi and run in the


### PR DESCRIPTION
#### Rationale
Artifactory Migration

#### Related Pull Requests
* https://github.com/LabKey/server/pull/278

#### Changes
* Update artifactory URL used for publishing
