### PR TITLE
Upgrade to Java 17

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version 2.0.0
+*Released*: TBD
+* Require Java 17 to build and run
+
 ## version 1.5.2
 *Released*: 14 July 2022
 * Add Connection.setUserAgent() and Connection.getUserAgent()

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for Java - Change Log
 
 ## version 2.0.0
-*Released*: TBD
+*Released*: 25 July 2022
 * Require Java 17 to build and run
 
 ## version 1.5.2

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "1.6.0-artifactorySaas-SNAPSHOT"
+version "2.0.0-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "2.0.0-SNAPSHOT"
+version "2.1.0-SNAPSHOT"
 
 dependencies {
     implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/labkey-client-api/gradle.properties
+++ b/labkey-client-api/gradle.properties
@@ -4,11 +4,8 @@
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # The source and target versions of Java for compilation tasks
-# We target a very old version to stay compatible with SAS. Our SAS macros wrap the Java remoteapi and run in the
-# SAS-bundled private JRE. Starting with SAS 9.4M6 (released in late 2018), the SAS Private JRE is based on Java 8.
-# https://support.sas.com/en/documentation/third-party-software-reference/9-4/support-for-java.html
-sourceCompatibility=1.8
-targetCompatibility=1.8
+sourceCompatibility=17
+targetCompatibility=17
 
 artifactoryPluginVersion=4.21.0
 gradlePluginsVersion=1.32.2


### PR DESCRIPTION
#### Rationale
Welcome to the modern world

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1179

#### Changes
* Require Java 17 to build and run
