### PR TITLE
Publish SAS v1.0.1

### DIFF
--- a/labkey-api-sas/CHANGELOG.md
+++ b/labkey-api-sas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # The LabKey Remote API Library for SAS - Change Log
 
+## version 1.0.1
+*Released* : 26 July 2022
+* Update labkeyClientApi to v1.5.2
+
 ## version 1.0.0
 *Released* : 5 June 2020
 

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -47,7 +47,7 @@ repositories {
 
 group 'org.labkey.api'
 
-version '1.0.0-artifactorySaaS-SNAPSHOT'
+version '1.0.1'
 
 // We add the TeamCity extension here if it doesn't exist because we will use the build
 // number property from TeamCity in the distribution artifact names, if present.

--- a/labkey-api-sas/build.gradle
+++ b/labkey-api-sas/build.gradle
@@ -47,7 +47,7 @@ repositories {
 
 group 'org.labkey.api'
 
-version '1.0.1'
+version '1.1.0-SNAPSHOT'
 
 // We add the TeamCity extension here if it doesn't exist because we will use the build
 // number property from TeamCity in the distribution artifact names, if present.


### PR DESCRIPTION
#### Rationale
SAS v1.0.1 is published so we bump to the next patch version.

#### Related Pull Requests
* #29 

#### Changes
* versions and dates
