### PR TITLE
Upgrade Apache HttpClient 4.5.13 -> 5.1.3

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,8 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 2.1.0-httpclient-SNAPSHOT (will be 3.0.0)
-*Released*: TBD
+## version 3.0.0
+*Released*: 14 September 2022
 * Migrate internal HTTP handling to use Apache HttpClient 5.1.x
+* Switch `StopImpersonatingCommand` to disable redirects (mimicking previous behavior)
+* Add `Connection.stopImpersonating()` and deprecate `stopImpersonate()`
 * Remove deprecated methods:
   * ApiVersionException() (use constructor that takes contentType)
   * CommandException() (use constructor that takes contentType)

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## version 2.?.?
 *Released*: TBD
+* Migrate internal HTTP handling to use Apache HttpClient 5.1.x
+* Remove deprecated methods:
+  * ApiVersionException() (use constructor that takes contentType)
+  * CommandException() (use constructor that takes contentType)
+  * Connection.getBaseUrl() (use Connection.getBaseURI())
+  * CredentialsProvider.configureRequest() (use variant that takes a URI)
+  * Filter.NON_BLANK (use Filter.NONBLANK)
+  * Filter.getCaption() (use Filter.getDisplayValue())
+  * Filter.getName() (use Filter.getUrlKey())
+  * Filter.isDataValueRequired() (use Filter.isValueRequired())
 * Remove SAS macros and wrapper classes
 * Add `CreateFolderCommand` and `CreateProjectCommand`
 * Update `LogoutCommand` to use POST

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 2.?.?
+## version 2.1.0-httpclient-SNAPSHOT (will be 3.0.0)
 *Released*: TBD
 * Migrate internal HTTP handling to use Apache HttpClient 5.1.x
 * Remove deprecated methods:
@@ -13,7 +13,8 @@
   * Filter.getName() (use Filter.getUrlKey())
   * Filter.isDataValueRequired() (use Filter.isValueRequired())
 * Remove SAS macros and wrapper classes
-* Add `CreateFolderCommand` and `CreateProjectCommand`
+* Add `CreateFolderCommand`
+* Add `CreateProjectCommand` (earliest compatible LabKey Server version: 22.3.0)
 * Update `LogoutCommand` to use POST
 
 ## version 2.0.0

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "2.1.0-httpclient"
+version "2.1.0-httpclient-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "2.1.0-httpclient-SNAPSHOT"
+version "3.1.0-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,20 +57,19 @@ repositories {
 
 group "org.labkey.api"
 
-version "2.1.0-SNAPSHOT"
+version "2.1.0-httpclient"
 
 dependencies {
-    implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")
             {
                 // exclude this because it gets in the way of our own JSON object implementations from server/api
                 exclude group: "org.json", module:"json"
             }
+    api "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"
+    api "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
     implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
     implementation "commons-logging:commons-logging:${commonsLoggingVersion}"
-    api "org.apache.httpcomponents:httpclient:${httpclientVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"
-    api "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
 }
 
 configurations.all

--- a/labkey-client-api/gradle.properties
+++ b/labkey-client-api/gradle.properties
@@ -14,9 +14,9 @@ commonsCodecVersion=1.15
 commonsLoggingVersion=1.2
 
 hamcrestVersion=1.3
-httpclientVersion=4.5.13
-httpcoreVersion=4.4.14
-httpmimeVersion=4.5.13
+
+httpclient5Version=5.1.3
+httpcore5Version=5.1.4
 
 jsonSimpleVersion=1.1.1
 

--- a/labkey-client-api/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
@@ -15,9 +15,9 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.auth.AuthenticationException;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 
 import java.net.URI;
 

--- a/labkey-client-api/src/org/labkey/remoteapi/ApiVersionException.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/ApiVersionException.java
@@ -24,14 +24,6 @@ import java.util.Map;
  */
 public class ApiVersionException extends CommandException
 {
-    /**
-     * @deprecated Use {@link #ApiVersionException(String, int, Map, String, String)}
-     */
-    ApiVersionException(String message, int statusCode, Map<String, Object> properties, String responseText)
-    {
-        this(message, statusCode, properties, responseText, null);
-    }
-
     ApiVersionException(String message, int statusCode, Map<String, Object> properties, String responseText, String contentType)
     {
         super(message, statusCode, properties, responseText, contentType);

--- a/labkey-client-api/src/org/labkey/remoteapi/BasicAuthCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/BasicAuthCredentialsProvider.java
@@ -15,14 +15,14 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.AuthenticationException;
-import org.apache.http.auth.Credentials;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.auth.BasicScheme;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 
 import java.net.URI;
 
@@ -43,12 +43,10 @@ public class BasicAuthCredentialsProvider implements CredentialsProvider
     @Override
     public void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException
     {
-        AuthScope scope = new AuthScope(baseURI.getHost(), AuthScope.ANY_PORT, AuthScope.ANY_REALM);
         BasicCredentialsProvider provider = new BasicCredentialsProvider();
-        Credentials credentials = new UsernamePasswordCredentials(_email, _password);
+        AuthScope scope = new AuthScope(baseURI.getHost(), -1);
+        Credentials credentials = new UsernamePasswordCredentials(_email, _password.toCharArray());
         provider.setCredentials(scope, credentials);
-
         httpClientContext.setCredentialsProvider(provider);
-        request.addHeader(new BasicScheme().authenticate(credentials, request, httpClientContext));
     }
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/Command.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Command.java
@@ -18,12 +18,12 @@ package org.labkey.remoteapi;
 import org.apache.commons.codec.EncoderException;
 import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.Header;
-import org.apache.http.auth.AuthenticationException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.net.URIBuilder;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
@@ -256,12 +256,12 @@ public class Command<ResponseType extends CommandResponse>
 
         public String getStatusText()
         {
-            return _httpResponse.getStatusLine().getReasonPhrase();
+            return _httpResponse.getReasonPhrase();
         }
 
         public int getStatusCode()
         {
-            return _httpResponse.getStatusLine().getStatusCode();
+            return _httpResponse.getCode();
         }
 
         public String getContentType()
@@ -328,7 +328,7 @@ public class Command<ResponseType extends CommandResponse>
         {
             //construct and initialize the HttpUriRequest
             request = getHttpRequest(connection, folderPath);
-            LogFactory.getLog(Command.class).info("Requesting URL: " + request.getURI().toString());
+            LogFactory.getLog(Command.class).info("Requesting URL: " + request.getRequestUri().toString());
 
             //execute the request
             httpResponse = connection.executeRequest(request, getTimeout());
@@ -460,7 +460,7 @@ public class Command<ResponseType extends CommandResponse>
         //(indicating that it has already been escaped)
         String queryString = getQueryString();
         if (null != queryString)
-            uri = new URIBuilder(uri).setQuery(queryString).build();
+            uri = new URIBuilder(uri).setCustomQuery(queryString).build();
 
         return createRequest(uri);
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/Command.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Command.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.commons.codec.EncoderException;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -447,15 +446,13 @@ public class Command<ResponseType extends CommandResponse>
 // TODO        (Dave 11/11/14 -- as far as I can tell the default of the AuthSchemes is to automatically handle challenges
 //        method.setDoAuthentication(true);
 
+        // NOTE: Fairly sure that the "unescaped" comment below is obsolete
+        // TODO: Combine getActionUrl() and addParameters() into a single method
         //construct a URI from the results of the getActionUrl method
         //note that this method returns an unescaped URL, so pass
         //false for the second parameter to escape it
         URI uri = getActionUrl(connection, folderPath);
-
-        // Note: setCustomQuery() encodes the query string
-        String queryString = getQueryString();
-        if (null != queryString)
-            uri = new URIBuilder(uri).setCustomQuery(queryString).build();
+        uri = addParameters(uri);
 
         return createRequest(uri);
     }
@@ -482,7 +479,7 @@ public class Command<ResponseType extends CommandResponse>
      * @return The URL
      * @throws URISyntaxException if the uri constructed from the parameters is malformed
      */
-    protected URI getActionUrl(Connection connection, String folderPath) throws URISyntaxException
+    private URI getActionUrl(Connection connection, String folderPath) throws URISyntaxException
     {
         URI uri = connection.getBaseURI();
 
@@ -515,12 +512,12 @@ public class Command<ResponseType extends CommandResponse>
     }
 
     /**
-     * Returns unencoded query string portion of the URL for this command.
+     * Adds all parameters to the passed URI
      * <p>
-     * @return The query string
-     * @throws CommandException Thrown if there is a problem encoding the query string parameter names or values
+     * @return The URI with parameters added
+     * @throws CommandException Thrown if there is a problem building the URI
      */
-    protected String getQueryString() throws CommandException
+    protected URI addParameters(URI uri) throws CommandException, URISyntaxException
     {
         Map<String, Object> params = getParameters();
 
@@ -528,45 +525,42 @@ public class Command<ResponseType extends CommandResponse>
         if (getRequiredVersion() > 0)
             params.put(CommonParameters.apiVersion.name(), getRequiredVersion());
 
-        StringBuilder qstring = new StringBuilder();
-        try
+        if (params.isEmpty())
+            return uri;
+
+        URIBuilder builder = new URIBuilder(uri);
+
+        for (String name : params.keySet())
         {
-            for (String name : params.keySet())
+            Object value = params.get(name);
+            if (value instanceof Collection<?> col)
             {
-                Object value = params.get(name);
-                if (value instanceof Collection<?> col)
+                for (Object o : col)
                 {
-                    for (Object o : col)
-                    {
-                        appendParameter(qstring, name, o);
-                    }
-                }
-                else
-                {
-                    appendParameter(qstring, name, value);
+                    addParameter(builder, name, o);
                 }
             }
+            else
+            {
+                addParameter(builder, name, value);
+            }
         }
-        catch(EncoderException e)
+
+        try
+        {
+            return builder.build();
+        }
+        catch (URISyntaxException e)
         {
             throw new CommandException(e.getMessage());
         }
-
-        return qstring.length() > 0 ? qstring.toString() : null;
     }
 
-    private void appendParameter(StringBuilder qstring, String name, Object value)
-            throws EncoderException
+    private void addParameter(URIBuilder builder, String name, Object value)
     {
         String strValue = null == value ? null : getParamValueAsString(value, name);
         if (null != strValue)
-        {
-            if (qstring.length() > 0)
-                qstring.append('&');
-            qstring.append(name);
-            qstring.append('=');
-            qstring.append(strValue);
-        }
+            builder.addParameter(name, strValue);
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/CommandException.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/CommandException.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.impl.EnglishReasonPhraseCatalog;
+import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 
 import java.util.Locale;
 import java.util.Map;
@@ -49,18 +49,6 @@ public class CommandException extends Exception
     public CommandException(String message)
     {
         this(message, 0, null, null, null);
-    }
-
-    /**
-     * @param message The message text (should not be null).
-     * @param statusCode The HTTP status code.
-     * @param properties The exception property map (may be null)
-     * @param responseText The full response text (may be null)
-     * @deprecated Use {@link #CommandException(String, int, Map, String, String)}
-     */
-    public CommandException(String message, int statusCode, Map<String, Object> properties, String responseText)
-    {
-        this(message, statusCode, properties, responseText, null);
     }
 
     /**

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -29,10 +29,14 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.protocol.RedirectStrategy;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
+import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.labkey.remoteapi.security.EnsureLoginCommand;
 import org.labkey.remoteapi.security.ImpersonateUserCommand;
@@ -239,7 +243,18 @@ public class Connection
             .setConnectionManager(connectionManager)
             .setDefaultRequestConfig(RequestConfig.custom().setResponseTimeout(getTimeout(), TimeUnit.MILLISECONDS).build())
             .setDefaultCookieStore(_httpClientContext.getCookieStore())
-            .setDefaultCredentialsProvider(_httpClientContext.getCredentialsProvider());
+            .setDefaultCredentialsProvider(_httpClientContext.getCredentialsProvider())
+            .setRedirectStrategy(new RedirectStrategy() {
+                @Override
+                public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException {
+                    return false;
+                }
+
+                @Override
+                public URI getLocationURI(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException {
+                    return null;
+                }
+            });
 
         if (_proxyHost != null && _proxyPort != null)
             builder.setProxy(new HttpHost(_proxyHost, _proxyPort));

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -351,7 +351,7 @@ public class Connection
      * project in which they have admin permission.
      *
      * @param email The user to impersonate
-     * @see Connection#stopImpersonate()
+     * @see Connection#stopImpersonating()
      * @return this connection
      * @throws IOException Thrown if there was an IO problem.
      * @throws CommandException if the server returned a non-success status code.
@@ -371,7 +371,7 @@ public class Connection
      *
      * @param email The user to impersonate
      * @param projectPath The project path within which the user will be impersonated.
-     * @see Connection#stopImpersonate()
+     * @see Connection#stopImpersonating()
      * @return this connection
      * @throws IOException Thrown if there was an IO problem.
      * @throws CommandException if the server returned a non-success status code.
@@ -395,15 +395,14 @@ public class Connection
      * @throws IOException Thrown if there was an IO problem.
      * @throws CommandException if the server returned a non-success status code.
      */
-    public Connection stopImpersonate() throws IOException, CommandException
+    public Connection stopImpersonating() throws IOException, CommandException
     {
         if (_impersonateUser != null)
         {
             CommandResponse resp = new StopImpersonatingCommand().execute(this, _impersonatePath);
-            resp = new StopImpersonatingCommand().execute(this, _impersonatePath);
 
-            // on success, a 200 response is returned
-            if (resp.getStatusCode() != 200)
+            // on success, a 302 response is returned (this command disables redirects)
+            if (resp.getStatusCode() != 302)
                 throw new CommandException("Failed to stop impersonating");
 
             _impersonateUser = null;
@@ -411,6 +410,12 @@ public class Connection
         }
 
         return this;
+    }
+
+    @Deprecated // Will be removed soon. Use stopImpersonating() instead.
+    public Connection stopImpersonate() throws IOException, CommandException
+    {
+        return stopImpersonating();
     }
 
     CloseableHttpResponse executeRequest(HttpUriRequest request, Integer timeout) throws IOException, URISyntaxException, AuthenticationException

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -29,14 +29,10 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
-import org.apache.hc.client5.http.protocol.RedirectStrategy;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
-import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
-import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.labkey.remoteapi.security.EnsureLoginCommand;
 import org.labkey.remoteapi.security.ImpersonateUserCommand;
@@ -243,18 +239,7 @@ public class Connection
             .setConnectionManager(connectionManager)
             .setDefaultRequestConfig(RequestConfig.custom().setResponseTimeout(getTimeout(), TimeUnit.MILLISECONDS).build())
             .setDefaultCookieStore(_httpClientContext.getCookieStore())
-            .setDefaultCredentialsProvider(_httpClientContext.getCredentialsProvider())
-            .setRedirectStrategy(new RedirectStrategy() {
-                @Override
-                public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException {
-                    return false;
-                }
-
-                @Override
-                public URI getLocationURI(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException {
-                    return null;
-                }
-            });
+            .setDefaultCredentialsProvider(_httpClientContext.getCredentialsProvider());
 
         if (_proxyHost != null && _proxyPort != null)
             builder.setProxy(new HttpHost(_proxyHost, _proxyPort));
@@ -415,9 +400,10 @@ public class Connection
         if (_impersonateUser != null)
         {
             CommandResponse resp = new StopImpersonatingCommand().execute(this, _impersonatePath);
+            resp = new StopImpersonatingCommand().execute(this, _impersonatePath);
 
-            // on success, a 302 redirect response is returned
-            if (resp.getStatusCode() != 302)
+            // on success, a 200 response is returned
+            if (resp.getStatusCode() != 200)
                 throw new CommandException("Failed to stop impersonating");
 
             _impersonateUser = null;

--- a/labkey-client-api/src/org/labkey/remoteapi/CredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/CredentialsProvider.java
@@ -15,26 +15,16 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.auth.AuthenticationException;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * Created by adam on 4/15/2016.
  */
 public interface CredentialsProvider
 {
-    /**
-     * @deprecated Use {@link #configureRequest(URI, HttpUriRequest, HttpClientContext)}
-     */
-    @Deprecated
-    default void configureRequest(String baseUrl, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException, URISyntaxException
-    {
-        configureRequest(new URI(baseUrl), request, httpClientContext);
-    }
-
     void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException;
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/GuestCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/GuestCredentialsProvider.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 
 import java.net.URI;
 

--- a/labkey-client-api/src/org/labkey/remoteapi/NetrcCredentialsProvider.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/NetrcCredentialsProvider.java
@@ -15,9 +15,9 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.auth.AuthenticationException;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 
 import java.io.IOException;
 import java.net.URI;

--- a/labkey-client-api/src/org/labkey/remoteapi/PostCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/PostCommand.java
@@ -15,10 +15,10 @@
  */
 package org.labkey.remoteapi;
 
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.json.simple.JSONObject;
 
 import java.net.URI;

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/ImportRunCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/ImportRunCommand.java
@@ -15,10 +15,10 @@
  */
 package org.labkey.remoteapi.assay;
 
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.core5.http.ContentType;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.labkey.remoteapi.PostCommand;

--- a/labkey-client-api/src/org/labkey/remoteapi/ms2/StartSearchCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/ms2/StartSearchCommand.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.remoteapi.ms2;
 
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.json.simple.JSONObject;
 import org.labkey.remoteapi.Command;
 

--- a/labkey-client-api/src/org/labkey/remoteapi/query/Filter.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/Filter.java
@@ -85,8 +85,6 @@ public class Filter
         //
 
         ISBLANK("Is Blank", "isblank", "MISSING", false),
-        @Deprecated // Use NONBLANK instead... that name matches CompareType operator
-        NON_BLANK("Is Not Blank", "isnonblank", "NOT_MISSING", false),
         NONBLANK("Is Not Blank", "isnonblank", "NOT_MISSING", false),
 
         MV_INDICATOR("Has Missing Value Indicator", "hasmvvalue", "MV_INDICATOR", false),
@@ -158,24 +156,6 @@ public class Filter
         public static Operator getOperatorFromUrlKey(String urlKey)
         {
             return _urlKeyToOperator.get(urlKey);
-        }
-
-        @Deprecated // Use getDisplayValue()... this method is for backward compatibility
-        public String getCaption()
-        {
-            return _displayValue;
-        }
-
-        @Deprecated // Use getUrlKey()... this method is for backward compatibility
-        public String getName()
-        {
-            return _urlKey;
-        }
-
-        @Deprecated // Use isDataValueRequired()... this method is for backward compatibility
-        public boolean isValueRequired()
-        {
-            return _dataValueRequired;
         }
     }
 

--- a/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/ImportDataCommand.java
@@ -15,10 +15,10 @@
  */
 package org.labkey.remoteapi.query;
 
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.core5.http.ContentType;
 import org.json.simple.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
@@ -244,7 +244,7 @@ public class ImportDataCommand extends PostCommand<ImportDataResponse>
     }
 
     @Override
-    protected HttpUriRequest createRequest(URI uri)
+    protected HttpUriRequestBase createRequest(URI uri)
     {
         Objects.requireNonNull(_schemaName, "schemaName required");
         Objects.requireNonNull(_queryName, "queryName required");

--- a/labkey-client-api/src/org/labkey/remoteapi/query/SelectRowsCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/SelectRowsCommand.java
@@ -202,9 +202,10 @@ public class SelectRowsCommand extends BaseQueryCommand<SelectRowsResponse> impl
         return new SelectRowsResponse(text, status, contentType, json, this.copy());
     }
 
+    @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String,Object> params = new HashMap<>();
         params.put("schemaName", getSchemaName());
         params.put("query.queryName", getQueryName());
         if(null != getViewName())

--- a/labkey-client-api/src/org/labkey/remoteapi/security/BaseCreateFolderCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/BaseCreateFolderCommand.java
@@ -1,13 +1,12 @@
 package org.labkey.remoteapi.security;
 
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.PostCommand;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,16 +75,9 @@ public abstract class BaseCreateFolderCommand<COMMAND extends BaseCreateFolderCo
     @Override
     protected HttpUriRequest createRequest(URI uri)
     {
-        try
-        {
-            // CreateFolderAction and CreateProjectAction are not real API actions, so we POST form data instead of JSON
-            HttpPost request = new HttpPost(uri);
-            request.setEntity(new UrlEncodedFormEntity(getPostData()));
-            return request;
-        }
-        catch (UnsupportedEncodingException e)
-        {
-            throw new RuntimeException(e);
-        }
+        // CreateFolderAction and CreateProjectAction are not real API actions, so we POST form data instead of JSON
+        HttpPost request = new HttpPost(uri);
+        request.setEntity(new UrlEncodedFormEntity(getPostData()));
+        return request;
     }
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/security/CreateProjectCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/CreateProjectCommand.java
@@ -1,6 +1,6 @@
 package org.labkey.remoteapi.security;
 
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 
 import java.util.List;
 

--- a/labkey-client-api/src/org/labkey/remoteapi/security/StopImpersonatingCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/StopImpersonatingCommand.java
@@ -1,7 +1,12 @@
 package org.labkey.remoteapi.security;
 
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.PostCommand;
+
+import java.net.URI;
 
 /**
  * Stop impersonating a user.
@@ -10,6 +15,21 @@ public class StopImpersonatingCommand extends PostCommand<CommandResponse>
 {
     public StopImpersonatingCommand()
     {
-        super("login", "stopImpersonatingApi.api");
+        // TODO: At some point (when we're okay with breaking compatibility with pre-22.10 servers) switch this to
+        // stopImpersonatingApi.api, a true API action added 9/22
+        super("login", "stopImpersonating.api");
+    }
+
+    @Override
+    protected HttpUriRequest createRequest(URI uri)
+    {
+        // Disable redirects just for this request
+        HttpPost request = (HttpPost)super.createRequest(uri); // CONSIDER: generify Command with request type?
+        RequestConfig oldConfig = request.getConfig();
+        RequestConfig.Builder builder = oldConfig != null ? RequestConfig.copy(oldConfig) : RequestConfig.custom();
+        builder.setRedirectsEnabled(false);
+        request.setConfig(builder.build());
+
+        return request;
     }
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/security/StopImpersonatingCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/StopImpersonatingCommand.java
@@ -10,6 +10,6 @@ public class StopImpersonatingCommand extends PostCommand<CommandResponse>
 {
     public StopImpersonatingCommand()
     {
-        super("login", "stopImpersonating.api");
+        super("login", "stopImpersonatingApi.api");
     }
 }


### PR DESCRIPTION
#### Rationale
Latest

#### Related Pull Requests
* Upgrade Apache HttpClient 4.5.13 -> 5.1.3
* Switch to Basic auth challenge/response, instead of pre-emptive auth
* Switch self-signed cert handling to HttpClient 5.x approach: `SSLConnectionSocketFactory` must now be set on the `ConnectionManager`, not on each `HttpClientBuilder`.
* Switch to adding parameters one-by-one to ensure correct escaping (see `Command.addParameters()`). `setCustomQuery()` now requires an unescaped query string, which is not compatible with tricky characters (e.g., "&" in a schema name).
* Remove deprecated methods