### PR TITLE
Add support for creating Freezer Manager freezer hierarchies via StorageController APIs

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,12 +1,12 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version TBD
-*Released*: TBD September 2022
+## version 3.1.0
+*Released*: 20 September 2022
+* Add support for creating Freezer Manager freezer hierarchies via StorageController APIs (earliest compatible LabKey Server version: 22.10.0)
+  * CreateCommand, UpdateCommand, DeleteCommand
 * Restore proactive authentication behavior. A change in v3.0.0 caused some invocations of `@NoPermissionsRequired`
   actions (e.g., `GetContainersCommand`) to use guest credentials instead of the configured user credentials. The library
   now always authenticates using the configured credentials, matching pre-v3.0.0 behavior.
-* Add support for creating Freezer Manager freezer hierarchies via StorageController APIs (earliest compatible LabKey Server version: 22.10.0)
-  * CreateCommand, UpdateCommand, DeleteCommand
 
 ## version 3.0.0
 *Released*: 14 September 2022

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version TBD
+*Released*: TBD September 2022
+* Add support for creating Freezer Manager freezer hierarchies via StorageController APIs (earliest compatible LabKey Server version: 22.10.0)
+  * CreateCommand, UpdateCommand, DeleteCommand
+
 ## version 3.0.0
 *Released*: 14 September 2022
 * Migrate internal HTTP handling to use Apache HttpClient 5.1.x

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## version TBD
 *Released*: TBD September 2022
+* Restore proactive authentication behavior. A change in v3.0.0 caused some invocations of `@NoPermissionsRequired`
+  actions (e.g., `GetContainersCommand`) to use guest credentials instead of the configured user credentials. The library
+  now always authenticates using the configured credentials, matching pre-v3.0.0 behavior.
 * Add support for creating Freezer Manager freezer hierarchies via StorageController APIs (earliest compatible LabKey Server version: 22.10.0)
   * CreateCommand, UpdateCommand, DeleteCommand
 
 ## version 3.0.0
 *Released*: 14 September 2022
 * Migrate internal HTTP handling to use Apache HttpClient 5.1.x
+* Migrate from preemptive to challenge-response Basic authentication 
 * Switch `StopImpersonatingCommand` to disable redirects (mimicking previous behavior)
 * Add `Connection.stopImpersonating()` and deprecate `stopImpersonate()`
 * Remove deprecated methods:

--- a/labkey-client-api/README.md
+++ b/labkey-client-api/README.md
@@ -21,7 +21,7 @@ compatibility with LabKey Server versions.
 ### Dependency Declaration
 To declare a dependency on this jar file, you can use the following in Gradle
 
-```compile(group: 'org.labkey.api', name: 'labkey-client-api', version: '1.2.0')```
+```compile(group: 'org.labkey.api', name: 'labkey-client-api', version: '3.1.0')```
 
 If using the LabKey Gradle plugins and building a LabKey module, it is best to 
 use this utility method instead to facilitate testing of any local changes to
@@ -59,7 +59,7 @@ When your feature development is done, you should:
 
 - Update the version number in the `build.gradle` file to the next logical SNAPSHOT version corresponding to your changes
 following the [SemVer](https://semver.org/) guidelines.  Make sure this is a SNAPSHOT version (e.g., `1.2.3-SNAPSHOT`).
-- Update the [change log](CHANGELOG.md) to document what has changed.  You can leave the release date and version alone at this 
+- Update the [change log](CHANGELOG.md) to document what has changed. You can leave the release date and version alone at this 
 point; they will get updated when the next release is published.
 - **TBD** Run tests using your SNAPSHOT version of the tests
 - Merge your branch into develop if appropriate tests are passing.

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "3.1.0-storageClientAPI-SNAPSHOT"
+version "3.2.0-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "3.1.0-SNAPSHOT"
+version "3.1.0-storageClientAPI-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")

--- a/labkey-client-api/src/org/labkey/remoteapi/CommandResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/CommandResponse.java
@@ -132,7 +132,7 @@ public class CommandResponse
      * @return The parsed data as a property map.
      */
     @SuppressWarnings("unchecked")
-    public Map<String,Object> getParsedData()
+    public Map<String, Object> getParsedData()
     {
         if(null == _data && null != getText()
                 && null != _contentType && _contentType.contains(Command.CONTENT_TYPE_JSON))
@@ -174,7 +174,7 @@ public class CommandResponse
      * @return The property value, or null if not found.
      */
     @SuppressWarnings("unchecked")
-    protected <T> T getProperty(String[] path, int pathIndex, Map<String,Object> parent)
+    protected <T> T getProperty(String[] path, int pathIndex, Map<String, Object> parent)
     {
         if(null == parent)
             return null;
@@ -206,7 +206,7 @@ public class CommandResponse
         {
             //recurse if prop is non-null and instance of map
             return (null != prop && prop instanceof Map)
-                ? (T)getProperty(path, pathIndex + 1, (Map<String,Object>)prop)
+                ? (T)getProperty(path, pathIndex + 1, (Map<String, Object>)prop)
                 : null;
         }
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/Connection.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Connection.java
@@ -278,7 +278,7 @@ public class Connection
     }
 
     /**
-     * If first request, prime the Connection by forcing authentication and populating CSRF & session info.
+     * If first request, prime the Connection by forcing authentication and populating CSRF and session info.
      * @param request HttpRequest that is about to be executed
      */
     protected void beforeExecute(HttpRequest request)

--- a/labkey-client-api/src/org/labkey/remoteapi/PostCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/PostCommand.java
@@ -61,7 +61,7 @@ public class PostCommand<ResponseType extends CommandResponse> extends Command<R
         super(controllerName, actionName);
     }
 
-    public PostCommand(PostCommand source)
+    public PostCommand(PostCommand<ResponseType> source)
     {
         super(source);
         if (null != source.getJsonObject())
@@ -120,6 +120,6 @@ public class PostCommand<ResponseType extends CommandResponse> extends Command<R
     @Override
     public PostCommand copy()
     {
-        return new PostCommand(this);
+        return new PostCommand<>(this);
     }
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/AssayListCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/AssayListCommand.java
@@ -117,6 +117,7 @@ public class AssayListCommand extends PostCommand<AssayListResponse>
         _id = id;
     }
 
+    @Override
     protected AssayListResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new AssayListResponse(text, status, contentType, json, this.copy());
@@ -134,9 +135,10 @@ public class AssayListCommand extends PostCommand<AssayListResponse>
         return obj;
     }
 
+    @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         if(null != getName())
             params.put("name", getName());
         if(null != getType())

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/AssayListResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/AssayListResponse.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.remoteapi.assay;
 
-import org.labkey.remoteapi.CommandResponse;
 import org.json.simple.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -52,7 +52,7 @@ public class AssayListResponse extends CommandResponse
      * about the particular assay definition.
      * @return The list of definitions.
      */
-    public List<Map<String,Object>> getDefinitions()
+    public List<Map<String, Object>> getDefinitions()
     {
         return getProperty("definitions");
     }
@@ -62,7 +62,7 @@ public class AssayListResponse extends CommandResponse
      * @param name The name of the assay definition to find.
      * @return The assay definition or null if not found.
      */
-    public Map<String,Object> getDefinition(String name)
+    public Map<String, Object> getDefinition(String name)
     {
         return findObject(getDefinitions(), "name", name);
     }
@@ -72,7 +72,7 @@ public class AssayListResponse extends CommandResponse
      * @param id The id of the assay definition to find.
      * @return The assay definition or null if not found.
      */
-    public Map<String,Object> getDefinition(int id)
+    public Map<String, Object> getDefinition(int id)
     {
         return findObject(getDefinitions(), "id", String.valueOf(id));
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/Batch.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/Batch.java
@@ -27,7 +27,7 @@ import java.util.List;
 */
 public class Batch extends ExpObject
 {
-    private List<Run> _runs = new ArrayList<Run>();
+    private List<Run> _runs = new ArrayList<>();
 
     public Batch()
     {

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/GetProtocolCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/GetProtocolCommand.java
@@ -34,7 +34,7 @@ public class GetProtocolCommand extends Command<ProtocolResponse>
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         if (_protocolId != null)
         {
             params.put("protocolId", _protocolId);

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/Run.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/Run.java
@@ -30,8 +30,8 @@ import java.util.Map;
 public class Run extends ExpObject
 {
     private String _comment;
-    private List<Data> _dataInputs = new ArrayList<Data>();
-    private List<Data> _dataOutputs = new ArrayList<Data>();
+    private List<Data> _dataInputs = new ArrayList<>();
+    private List<Data> _dataOutputs = new ArrayList<>();
     private List<Material> _materialInputs = new ArrayList<>();
     private List<Material> _materialOutputs = new ArrayList<>();
     private String _lsid;

--- a/labkey-client-api/src/org/labkey/remoteapi/assay/nab/NAbRunsCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/assay/nab/NAbRunsCommand.java
@@ -64,14 +64,16 @@ public class NAbRunsCommand extends BaseQueryCommand<NAbRunsResponse>
         _calculateNeut = source._calculateNeut;
     }
 
+    @Override
     protected NAbRunsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new NAbRunsResponse(text, status, contentType, json, this.copy());
     }
 
+    @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = super.getParameters();
+        Map<String, Object> params = super.getParameters();
 
         if (null != getAssayName())
             params.put("assayName", getAssayName());

--- a/labkey-client-api/src/org/labkey/remoteapi/collections/CaseInsensitiveHashMap.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/collections/CaseInsensitiveHashMap.java
@@ -79,7 +79,7 @@ public class CaseInsensitiveHashMap<V> extends HashMap<String, V>
         super.remove(correctCaseKey);
         //Now remove all the cached casings.
         //Need to do this in two loops to avoid modification while iterating
-        ArrayList<String> casings = new ArrayList<String>();
+        ArrayList<String> casings = new ArrayList<>();
         for (String s : caseMap.keySet())
         {
             if (s.equalsIgnoreCase(key))

--- a/labkey-client-api/src/org/labkey/remoteapi/domain/GetDomainCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/domain/GetDomainCommand.java
@@ -33,7 +33,7 @@ public class GetDomainCommand extends Command<DomainResponse>
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
 
         if (_schemaName != null && _queryName != null)
         {

--- a/labkey-client-api/src/org/labkey/remoteapi/experiment/LineageCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/experiment/LineageCommand.java
@@ -141,6 +141,7 @@ public class LineageCommand extends Command<LineageResponse>
         }
     }
 
+    @Override
     protected LineageResponse createResponse(String text, int statusCode, String contentType, JSONObject json)
     {
         return new LineageResponse(text, statusCode, contentType, json, this);
@@ -148,7 +149,7 @@ public class LineageCommand extends Command<LineageResponse>
 
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("lsids", _lsids);
         if (null != _parents)
             params.put("parents", _parents);

--- a/labkey-client-api/src/org/labkey/remoteapi/ms2/StartSearchCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/ms2/StartSearchCommand.java
@@ -100,7 +100,7 @@ public class StartSearchCommand extends Command<StartSearchResponse>
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String, Object> result = new HashMap<String, Object>();
+        Map<String, Object> result = new HashMap<>();
         result.put("path", _path);
         result.put("file", _files);
         result.put("protocol", _protocol);

--- a/labkey-client-api/src/org/labkey/remoteapi/query/BaseQueryCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/BaseQueryCommand.java
@@ -18,9 +18,9 @@ package org.labkey.remoteapi.query;
 import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -32,10 +32,10 @@ public abstract class BaseQueryCommand<ResponseType extends CommandResponse> ext
 {
     protected int _maxRows = -1;
     protected int _offset = 0;
-    protected List<Sort> _sorts = new ArrayList<Sort>();
-    protected List<Filter> _filters = new ArrayList<Filter>();
+    protected List<Sort> _sorts = new ArrayList<>();
+    protected List<Filter> _filters = new ArrayList<>();
     protected ContainerFilter _containerFilter;
-    private Map<String, String> _queryParameters = new HashMap<String, String>();
+    private Map<String, String> _queryParameters = new HashMap<>();
 
     public BaseQueryCommand(BaseQueryCommand<ResponseType> source)
     {

--- a/labkey-client-api/src/org/labkey/remoteapi/query/ExecuteSqlCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/ExecuteSqlCommand.java
@@ -320,6 +320,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
         _containerFilter = containerFilter;
     }
 
+    @Override
     protected SelectRowsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         assert null != _schemaName : "You must set the schemaName before executing!";
@@ -327,6 +328,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
         return new SelectRowsResponse(text, status, contentType, json, this.copy());
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public JSONObject getJsonObject()
     {
@@ -354,7 +356,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         if(null != getSorts() && getSorts().size() > 0)
             params.put("query.sort", Sort.getSortQueryStringParam(getSorts()));
         for (Map.Entry<String, String> entry : getQueryParameters().entrySet())

--- a/labkey-client-api/src/org/labkey/remoteapi/query/GetQueriesCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/GetQueriesCommand.java
@@ -15,11 +15,11 @@
  */
 package org.labkey.remoteapi.query;
 
-import org.labkey.remoteapi.Command;
 import org.json.simple.JSONObject;
+import org.labkey.remoteapi.Command;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 /*
 * User: Dave
@@ -94,11 +94,12 @@ public class GetQueriesCommand extends Command<GetQueriesResponse>
         _includeColumns = includeColumns;
     }
 
+    @Override
     public Map<String, Object> getParameters()
     {
         assert null != getSchemaName() : "You must set the schema name before executing the GetQueriesCommand!";
 
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("schemaName", getSchemaName());
 
         if(!isIncludeColumns())
@@ -109,6 +110,7 @@ public class GetQueriesCommand extends Command<GetQueriesResponse>
         return params;
     }
 
+    @Override
     protected GetQueriesResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new GetQueriesResponse(text, status, contentType, json, this.copy());

--- a/labkey-client-api/src/org/labkey/remoteapi/query/GetQueriesResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/GetQueriesResponse.java
@@ -15,13 +15,13 @@
  */
 package org.labkey.remoteapi.query;
 
-import org.labkey.remoteapi.CommandResponse;
 import org.json.simple.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Collections;
-import java.util.ArrayList;
 
 /*
 * User: Dave
@@ -54,12 +54,12 @@ public class GetQueriesResponse extends CommandResponse
      */
     public List<String> getQueryNames()
     {
-        List<Map<String,Object>> queries = getProperty("queries");
+        List<Map<String, Object>> queries = getProperty("queries");
         if(null == queries)
             return Collections.emptyList();
 
-        ArrayList<String> queryNames = new ArrayList<String>();
-        for(Map<String,Object> query : queries)
+        ArrayList<String> queryNames = new ArrayList<>();
+        for(Map<String, Object> query : queries)
         {
             if(query.containsKey("name"))
                 queryNames.add((String)query.get("name"));
@@ -80,11 +80,11 @@ public class GetQueriesResponse extends CommandResponse
 
     private Map<String, Object> getQuery(String queryName)
     {
-        List<Map<String,Object>> queries = getProperty("queries");
+        List<Map<String, Object>> queries = getProperty("queries");
         if(null == queries)
             return null;
 
-        for(Map<String,Object> query : queries)
+        for(Map<String, Object> query : queries)
         {
             if(queryName.equals(query.get("name")))
             {
@@ -110,11 +110,11 @@ public class GetQueriesResponse extends CommandResponse
         Map<String, Object> query = getQuery(queryName);
         if (query != null && query.containsKey("columns"))
         {
-            List<String> colNames = new ArrayList<String>();
-            List<Map<String,Object>> cols = (List<Map<String,Object>>)query.get("columns");
+            List<String> colNames = new ArrayList<>();
+            List<Map<String, Object>> cols = (List<Map<String, Object>>)query.get("columns");
             if(null != cols)
             {
-                for(Map<String,Object> col : cols)
+                for(Map<String, Object> col : cols)
                     colNames.add((String)col.get("name"));
             }
 

--- a/labkey-client-api/src/org/labkey/remoteapi/query/GetQueryDetailsCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/GetQueryDetailsCommand.java
@@ -88,12 +88,13 @@ public class GetQueryDetailsCommand extends Command<GetQueryDetailsResponse>
         _queryName = queryName;
     }
 
+    @Override
     public Map<String, Object> getParameters()
     {
         assert null != getSchemaName() : "You must set the schema name before executing the GetQueryDetailsCommand!";
         assert null != getQueryName() : "You must set the query name before executing the GetQueryDetailsCommand!";
 
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("schemaName", getSchemaName());
         params.put("queryName", getQueryName());
         params.put("includeSuggestedQueryColumns", _includeSuggestedQueryColumns);
@@ -101,6 +102,7 @@ public class GetQueryDetailsCommand extends Command<GetQueryDetailsResponse>
         return params;
     }
 
+    @Override
     protected GetQueryDetailsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new GetQueryDetailsResponse(text, status, contentType, json, this.copy());

--- a/labkey-client-api/src/org/labkey/remoteapi/query/GetQueryDetailsResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/GetQueryDetailsResponse.java
@@ -83,11 +83,11 @@ public class GetQueryDetailsResponse extends CommandResponse
     @SuppressWarnings("unchecked")
     public List<Column> getColumns()
     {
-        List<Column> result = new ArrayList<Column>();
+        List<Column> result = new ArrayList<>();
         JSONArray columns = getProperty("columns");
-        for (int i = 0; i < columns.size(); i++)
+        for (Object column : columns)
         {
-            result.add(new Column((Map<String, Object>)columns.get(i)));
+            result.add(new Column((Map<String, Object>) column));
         }
         return result;
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/query/GetSchemasCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/GetSchemasCommand.java
@@ -15,13 +15,8 @@
  */
 package org.labkey.remoteapi.query;
 
-import org.labkey.remoteapi.Command;
-import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.CommandException;
 import org.json.simple.JSONObject;
-
-import java.io.IOException;
+import org.labkey.remoteapi.Command;
 
 /*
 * User: Dave
@@ -44,6 +39,7 @@ public class GetSchemasCommand extends Command<GetSchemasResponse>
         super(source);
     }
 
+    @Override
     protected GetSchemasResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new GetSchemasResponse(text, status, contentType, json, this.copy());

--- a/labkey-client-api/src/org/labkey/remoteapi/query/RowMap.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/RowMap.java
@@ -24,7 +24,7 @@ import java.util.Map;
 */
 public class RowMap implements Row
 {
-    private Map<String,Object> _row;
+    private Map<String, Object> _row;
     private boolean _extendedFormat = false;
 
     public RowMap()
@@ -36,7 +36,7 @@ public class RowMap implements Row
         setMap(row);
     }
 
-    public void setMap(Map<String,Object> row)
+    public void setMap(Map<String, Object> row)
     {
         _row = row;
         _extendedFormat = _row.size() > 0 && row.values().iterator().next() instanceof Map;
@@ -45,31 +45,31 @@ public class RowMap implements Row
     public Object getValue(String columnName)
     {
         Object col = _row.get(columnName);
-        return null == col || !_extendedFormat ? col : ((Map<String,Object>)col).get("value");
+        return null == col || !_extendedFormat ? col : ((Map<String, Object>)col).get("value");
     }
 
     public Object getDisplayValue(String columnName)
     {
         Object col = _row.get(columnName);
-        return null == col || !_extendedFormat ? null : ((Map<String,Object>)col).get("displayValue");
+        return null == col || !_extendedFormat ? null : ((Map<String, Object>)col).get("displayValue");
     }
 
     public String getUrl(String columnName)
     {
         Object col = _row.get(columnName);
-        return null == col || !_extendedFormat ? null : (String)((Map<String,Object>)col).get("url");
+        return null == col || !_extendedFormat ? null : (String)((Map<String, Object>)col).get("url");
     }
 
     public String getMvValue(String columnName)
     {
         Object col = _row.get(columnName);
-        return null == col || !_extendedFormat ? null : (String)((Map<String,Object>)col).get("mvValue");
+        return null == col || !_extendedFormat ? null : (String)((Map<String, Object>)col).get("mvValue");
     }
 
     public Object getMvRawValue(String columnName)
     {
         Object col = _row.get(columnName);
-        return null == col || !_extendedFormat ? null : ((Map<String,Object>)col).get("mvRawValue");
+        return null == col || !_extendedFormat ? null : ((Map<String, Object>)col).get("mvRawValue");
     }
 
     @Override

--- a/labkey-client-api/src/org/labkey/remoteapi/query/RowsResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/RowsResponse.java
@@ -16,10 +16,10 @@
 package org.labkey.remoteapi.query;
 
 import org.apache.commons.logging.LogFactory;
-import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.Command;
-import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.json.simple.JSONObject;
+import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -61,7 +61,7 @@ abstract class RowsResponse extends CommandResponse
      * The most reliable way to work with them is to use the Number class.
      * For example:
      * <pre><code>
-     * for (Map&lt;String,Object&gt; row : response.getRows())
+     * for (Map&lt;String, Object&gt; row : response.getRows())
      * {
      *     Number key = (Number)row.get("Key");
      *     // use Number.intValue(), doubleValue(), longValue(), etc to get various primitive types
@@ -70,7 +70,7 @@ abstract class RowsResponse extends CommandResponse
      * @return The list of rows (each row is a Map), or null if
      * the rows list was not included in the response.
      */
-    public List<Map<String,Object>> getRows()
+    public List<Map<String, Object>> getRows()
     {
         return getProperty("rows");
     }
@@ -95,11 +95,11 @@ abstract class RowsResponse extends CommandResponse
         List<String> dateFields = new ArrayList<>();
         List<String> intFields = new ArrayList<>();
         List<String> floatFields = new ArrayList<>();
-        List<Map<String,Object>> fields = getProperty("metaData.fields");
+        List<Map<String, Object>> fields = getProperty("metaData.fields");
         if(null == fields)
             return;
 
-        for(Map<String,Object> field : fields)
+        for(Map<String, Object> field : fields)
         {
             String type = (String)field.get("type");
             if("date".equalsIgnoreCase(type))
@@ -115,7 +115,7 @@ abstract class RowsResponse extends CommandResponse
             return;
 
         //run the rows array and fixup date fields
-        List<Map<String,Object>> rows = getRows();
+        List<Map<String, Object>> rows = getRows();
         if(null == rows || rows.size() == 0)
             return;
 
@@ -191,11 +191,11 @@ abstract class RowsResponse extends CommandResponse
     private void caseInsensitizeRowMaps()
     {
         //copy the row maps into case-insensitive hash maps
-        List<Map<String,Object>> ciRows = new ArrayList<>();
+        List<Map<String, Object>> ciRows = new ArrayList<>();
 
         if (getRows() != null)
         {
-            for(Map<String,Object> row : getRows())
+            for(Map<String, Object> row : getRows())
             {
                 //copy the row map into a case-insensitive hash map
                 ciRows.add(new CaseInsensitiveHashMap<>(row));

--- a/labkey-client-api/src/org/labkey/remoteapi/query/RowsResponseRowset.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/RowsResponseRowset.java
@@ -16,8 +16,8 @@
 package org.labkey.remoteapi.query;
 
 import java.util.Iterator;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 /*
 * User: dave
@@ -26,9 +26,9 @@ import java.util.List;
 */
 public class RowsResponseRowset implements Rowset
 {
-    private List<Map<String,Object>> _rows;
+    private List<Map<String, Object>> _rows;
 
-    public RowsResponseRowset(List<Map<String,Object>> rows)
+    public RowsResponseRowset(List<Map<String, Object>> rows)
     {
         _rows = rows;
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/query/SaveRowsCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/SaveRowsCommand.java
@@ -20,11 +20,7 @@ import org.json.simple.JSONObject;
 import org.labkey.remoteapi.PostCommand;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /*
 * User: Dave
@@ -62,7 +58,7 @@ import java.util.Map;
  *  //Insert Rows Command
  *  InsertRowsCommand cmd = new InsertRowsCommand("lists", "People");
  *
- *  Map&lt;String,Object&gt; row = new HashMap&lt;String,Object&gt;();
+ *  Map&lt;String, Object&gt; row = new HashMap&lt;String, Object&gt;();
  *  row.put("FirstName", "Insert");
  *  row.put("LastName", "Test");
  *
@@ -74,7 +70,7 @@ import java.util.Map;
  *
  *  //Update Rows Command
  *  UpdateRowsCommand cmdUpd = new UpdateRowsCommand("lists", "People");
- *  row = new HashMap&lt;String,Object&gt;();
+ *  row = new HashMap&lt;String, Object&gt;();
  *  row.put("Key", newKey);
  *  row.put("LastName", "Test UPDATED");
  *  cmdUpd.addRow(row);
@@ -82,7 +78,7 @@ import java.util.Map;
  *
  *  //Delete Rows Command
  *  DeleteRowsCommand cmdDel = new DeleteRowsCommand("lists", "People");
- *  row = new HashMap&lt;String,Object&gt;();
+ *  row = new HashMap&lt;String, Object&gt;();
  *  row.put("Key", newKey);
  *  cmdDel.addRow(row);
  *  resp = cmdDel.execute(cn, "PROJECT_NAME");
@@ -93,7 +89,7 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
     private String _schemaName;
     private String _queryName;
     private Map<String, Object> _extraContext;
-    private List<Map<String,Object>> _rows = new ArrayList<Map<String,Object>>();
+    private List<Map<String, Object>> _rows = new ArrayList<>();
 
     /**
      * Constructs a new SaveRowsCommand for a given schema, query and action name.
@@ -117,10 +113,10 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
         _schemaName = source._schemaName;
         _extraContext = source._extraContext;
         //deep copy rows
-        _rows = new ArrayList<Map<String,Object>>();
-        for(Map<String,Object> row : source._rows)
+        _rows = new ArrayList<>();
+        for(Map<String, Object> row : source._rows)
         {
-            _rows.add(new HashMap<String,Object>(row));
+            _rows.add(new HashMap<>(row));
         }
     }
 
@@ -201,7 +197,7 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
      * Adds a row to the list of rows to be sent to the server.
      * @param row The row to add
      */
-    public void addRow(Map<String,Object> row)
+    public void addRow(Map<String, Object> row)
     {
         _rows.add(row);
     }
@@ -211,6 +207,7 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
      * schema name, query name and rows list.
      * @return The JSON object to send.
      */
+    @Override
     @SuppressWarnings("unchecked")
     public JSONObject getJsonObject()
     {
@@ -227,7 +224,7 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
         if(null != getRows())
         {
             SimpleDateFormat fmt = new SimpleDateFormat("d MMM yyyy HH:mm:ss Z");
-            for(Map<String,Object> row : getRows())
+            for(Map<String, Object> row : getRows())
             {
                 JSONObject jsonRow;
                 if(row instanceof JSONObject) //optimization
@@ -236,7 +233,7 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
                 {
                     jsonRow = new JSONObject();
                     //row map entries must be scalar values (no embedded maps or arrays)
-                    for(Map.Entry<String,Object> entry : row.entrySet())
+                    for(Map.Entry<String, Object> entry : row.entrySet())
                     {
                         Object value = entry.getValue();
 
@@ -253,10 +250,12 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
         return json;
     }
 
+    @Override
     protected SaveRowsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new SaveRowsResponse(text, status, contentType, json, this.copy());
     }
 
+    @Override
     public abstract SaveRowsCommand copy();
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/query/SelectRowsCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/SelectRowsCommand.java
@@ -49,7 +49,7 @@ import java.util.Map;
  *     Connection cn = new Connection("https://www.labkey.org");
  *     SelectRowsCommand cmd = new SelectRowsCommand("study", "Physical Exam");
  *     SelectRowsResponse response = cmd.execute(cn, "Home/Study/demo");
- *     for(Map&lt;String,Object&gt; row : response.getRows())
+ *     for(Map&lt;String, Object&gt; row : response.getRows())
  *     {
  *         System.out.println(row.get("ParticipantId") + " weighs " + row.get("APXwtkg"));
  *     }
@@ -61,7 +61,7 @@ public class SelectRowsCommand extends BaseQueryCommand<SelectRowsResponse> impl
     private String _schemaName;
     private String _queryName;
     private String _viewName;
-    private List<String> _columns = new ArrayList<String>();
+    private List<String> _columns = new ArrayList<>();
 
     /**
      * Constructs a new SelectRowsCommand for the given schema
@@ -197,6 +197,7 @@ public class SelectRowsCommand extends BaseQueryCommand<SelectRowsResponse> impl
      * @param json The parsed JSONObject (or null if JSON was not returned).
      * @return A SelectRowsResponse object.
      */
+    @Override
     protected SelectRowsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new SelectRowsResponse(text, status, contentType, json, this.copy());
@@ -205,7 +206,7 @@ public class SelectRowsCommand extends BaseQueryCommand<SelectRowsResponse> impl
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("schemaName", getSchemaName());
         params.put("query.queryName", getQueryName());
         if(null != getViewName())

--- a/labkey-client-api/src/org/labkey/remoteapi/query/SelectRowsResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/SelectRowsResponse.java
@@ -97,7 +97,7 @@ public class SelectRowsResponse extends RowsResponse
      */
     public Rowset getRowset()
     {
-        return new RowsResponseRowset((List<Map<String,Object>>)getProperty("rows"));
+        return new RowsResponseRowset(getProperty("rows"));
     }
 
     /**
@@ -113,7 +113,7 @@ public class SelectRowsResponse extends RowsResponse
      * </ul>
      * @return The meta-data section of the response, or null if no section was returned by the server.
      */
-    public Map<String,Object> getMetaData()
+    public Map<String, Object> getMetaData()
     {
         return getProperty("metaData");
     }
@@ -124,13 +124,13 @@ public class SelectRowsResponse extends RowsResponse
      * @param columnName The requested column name.
      * @return The meta-data for that column or null if that column was not found.
      */
-    public Map<String,Object> getMetaData(String columnName)
+    public Map<String, Object> getMetaData(String columnName)
     {
         assert null != columnName;
-        List<Map<String,Object>> metaData = getProperty("metaData.fields");
+        List<Map<String, Object>> metaData = getProperty("metaData.fields");
         if(null == metaData)
             return null;
-        for(Map<String,Object> entry : metaData)
+        for(Map<String, Object> entry : metaData)
         {
             if(columnName.equalsIgnoreCase((String)entry.get("name")))
                 return entry;
@@ -145,7 +145,7 @@ public class SelectRowsResponse extends RowsResponse
      */
     public ColumnDataType getColumnDataType(String columnName)
     {
-        Map<String,Object> meta = getMetaData(columnName);
+        Map<String, Object> meta = getMetaData(columnName);
         if(null == meta)
             return null;
         String type = (String)meta.get("type");
@@ -181,7 +181,7 @@ public class SelectRowsResponse extends RowsResponse
      * </ul> 
      * @return The column model, or null if none was returned by the server.
      */
-    public List<Map<String,Object>> getColumnModel()
+    public List<Map<String, Object>> getColumnModel()
     {
         return getProperty("columnModel");
     }
@@ -192,9 +192,8 @@ public class SelectRowsResponse extends RowsResponse
      * @param columnName The column name.
      * @return The properties for the specified column, or null if the column was not found.
      */
-    public Map<String,Object> getColumnModel(String columnName)
+    public Map<String, Object> getColumnModel(String columnName)
     {
         return findObject(getColumnModel(), "dataIndex", columnName);
     }
-
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/query/SqlExecuteCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/SqlExecuteCommand.java
@@ -43,7 +43,7 @@ public class SqlExecuteCommand extends PostCommand<CommandResponse>
 
     private String _schemaName;
     private String _sql;
-    private Map<String,Object> _queryParameters = new HashMap<>();
+    private Map<String, Object> _queryParameters = new HashMap<>();
     private String _sep = us_char + "\t";
     private String _eol = us_char + "\n";
     private boolean _compact = true;
@@ -145,6 +145,7 @@ public class SqlExecuteCommand extends PostCommand<CommandResponse>
         return _sep;
     }
 
+    @Override
     public JSONObject getJsonObject()
     {
         JSONObject json = new JSONObject();

--- a/labkey-client-api/src/org/labkey/remoteapi/query/TruncateTableCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/query/TruncateTableCommand.java
@@ -95,6 +95,7 @@ public class TruncateTableCommand extends PostCommand<TruncateTableResponse>
         return new TruncateTableResponse(text, status, contentType, json, copy());
     }
 
+    @Override
     public JSONObject getJsonObject()
     {
         JSONObject json = new JSONObject();

--- a/labkey-client-api/src/org/labkey/remoteapi/security/GetContainersCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/GetContainersCommand.java
@@ -51,6 +51,7 @@ public class GetContainersCommand extends Command<GetContainersResponse>
         _includeSubfolders = includeSubfolders;
     }
 
+    @Override
     protected GetContainersResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new GetContainersResponse(text, status, contentType, json, this.copy());
@@ -58,7 +59,7 @@ public class GetContainersCommand extends Command<GetContainersResponse>
 
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("includeSubfolders", _includeSubfolders);
         return params;
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/security/GetContainersResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/GetContainersResponse.java
@@ -15,11 +15,11 @@
  */
 package org.labkey.remoteapi.security;
 
-import org.labkey.remoteapi.CommandResponse;
 import org.json.simple.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
 
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 /*
 * User: Dave
@@ -45,7 +45,7 @@ public class GetContainersResponse extends CommandResponse
 
     public Integer getUserPermissions(String containerPath)
     {
-        Map<String,Object> containerInfo = findContainer(containerPath, getParsedData());
+        Map<String, Object> containerInfo = findContainer(containerPath, getParsedData());
         return (null == containerInfo) ? null : ((Number)containerInfo.get("userPermissions")).intValue();
     }
 
@@ -62,7 +62,7 @@ public class GetContainersResponse extends CommandResponse
     }
 
     @SuppressWarnings("unchecked")
-    protected Map<String,Object> findContainer(String containerPath, Map<String,Object> root)
+    protected Map<String, Object> findContainer(String containerPath, Map<String, Object> root)
     {
         if(null == containerPath)
             return root; //assumed by code above
@@ -76,7 +76,7 @@ public class GetContainersResponse extends CommandResponse
     }
 
     @SuppressWarnings("unchecked")
-    protected Map<String,Object> findContainer(String[] containerPath, int index, Map<String,Object> root)
+    protected Map<String, Object> findContainer(String[] containerPath, int index, Map<String, Object> root)
     {
         //if current root name doesn't match this path part, return null
         if(!containerPath[index].equalsIgnoreCase((String)root.get("name")))
@@ -86,9 +86,8 @@ public class GetContainersResponse extends CommandResponse
         if(containerPath.length - 1 == index)
             return root;
 
-        List<Map<String,Object>> children = (List<Map<String,Object>>)root.get("children");
-        Map<String,Object> child = (null == children) ? null : findObject(children, "name", containerPath[index + 1]);
+        List<Map<String, Object>> children = (List<Map<String, Object>>)root.get("children");
+        Map<String, Object> child = (null == children) ? null : findObject(children, "name", containerPath[index + 1]);
         return (null == child) ? null : findContainer(containerPath, index + 1, child);
     }
-
 }

--- a/labkey-client-api/src/org/labkey/remoteapi/security/GetGroupPermsCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/GetGroupPermsCommand.java
@@ -15,11 +15,11 @@
  */
 package org.labkey.remoteapi.security;
 
-import org.labkey.remoteapi.Command;
 import org.json.simple.JSONObject;
+import org.labkey.remoteapi.Command;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 /*
 * User: Dave
@@ -61,14 +61,16 @@ public class GetGroupPermsCommand extends Command<GetGroupPermsResponse>
         _includeSubfolders = includeSubfolders;
     }
 
+    @Override
     protected GetGroupPermsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
         return new GetGroupPermsResponse(text, status, contentType, json, this.copy());
     }
 
+    @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("includeSubfolders", isIncludeSubfolders());
         return params;
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/security/GetUsersCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/GetUsersCommand.java
@@ -38,7 +38,7 @@ public class GetUsersCommand extends Command<GetUsersResponse>
         super("user", "getUsers");
     }
 
-    public GetUsersCommand(Command source, String group, int groupId, String name)
+    public GetUsersCommand(GetUsersCommand source, String group, int groupId, String name)
     {
         super(source);
         setGroup(group);
@@ -115,7 +115,7 @@ public class GetUsersCommand extends Command<GetUsersResponse>
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String,Object> params = new HashMap<String,Object>();
+        Map<String, Object> params = new HashMap<>();
         if (_group != null)
         {
             params.put("group", _group);

--- a/labkey-client-api/src/org/labkey/remoteapi/security/GetUsersResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/GetUsersResponse.java
@@ -73,7 +73,7 @@ public class GetUsersResponse extends CommandResponse
     public List<UserInfo> getUsersInfo()
     {
         List<Map<String, Object>> usersNode = (List<Map<String, Object>>)getParsedData().get("users");
-        List<UserInfo> result = new ArrayList<UserInfo>();
+        List<UserInfo> result = new ArrayList<>();
         for (Map<String, Object> map : usersNode)
         {
             result.add(new UserInfo(map));

--- a/labkey-client-api/src/org/labkey/remoteapi/security/GroupMembersCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/security/GroupMembersCommand.java
@@ -15,12 +15,12 @@
  */
 package org.labkey.remoteapi.security;
 
+import org.json.simple.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.PostCommand;
-import org.json.simple.JSONObject;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 /*
 * User: dave
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 public abstract class GroupMembersCommand extends PostCommand<CommandResponse>
 {
     private int _groupId = 0;
-    private List<Integer> _principals = new ArrayList<Integer>();
+    private final List<Integer> _principals = new ArrayList<>();
 
     protected GroupMembersCommand(String actionName, int groupId)
     {

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/BaseStorageCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/BaseStorageCommand.java
@@ -1,0 +1,37 @@
+package org.labkey.remoteapi.storage;
+
+import org.json.simple.JSONObject;
+import org.labkey.remoteapi.PostCommand;
+
+public abstract class BaseStorageCommand extends PostCommand<StorageCommandResponse>
+{
+    private StorageRow _storageRow;
+
+    public BaseStorageCommand(String action, StorageRow storageRow)
+    {
+        super("storage", action);
+        this._storageRow = storageRow;
+    }
+
+    @Override
+    public double getRequiredVersion()
+    {
+        return -1;
+    }
+
+    @Override
+    protected StorageCommandResponse createResponse(String text, int status, String contentType, JSONObject json)
+    {
+        return new StorageCommandResponse(text, status, contentType, json, this);
+    }
+
+    /**
+     * Dynamically builds the JSON object to send based on the storageRow.
+     * @return The JSON object to send.
+     */
+    @Override
+    public JSONObject getJsonObject()
+    {
+        return _storageRow.toJsonObject();
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -1,0 +1,24 @@
+package org.labkey.remoteapi.storage;
+
+/**
+ * Create a new LabKey Freezer Manager storage item which can then be combined to create a freezer hierarchy.
+ * <p>
+ * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+ * Storage Unit Type, or Terminal Storage Location.
+ * <p>
+ * Examples:
+ * <pre><code>
+ *  // TODO ...
+ * </code></pre>
+ * */
+public class CreateCommand extends BaseStorageCommand
+{
+    /**
+     * Constructs a new CreateCommand for the given {@link StorageRow}.
+     * @param storageRow The details about the storage row to be created.
+     */
+    public CreateCommand(StorageRow storageRow)
+    {
+        super("create", storageRow);
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -1,14 +1,106 @@
 package org.labkey.remoteapi.storage;
 
 /**
+ * <p>
  * Create a new LabKey Freezer Manager storage item which can then be combined to create a freezer hierarchy.
- * <p>
+ * Freezer hierarchies consist of a top level freezer which can have any combination of child non-terminal storage
+ * locations (i.e. those that do not directly contain samples but can contain other units) and terminal storage
+ * locations (i.e. units in the freezer which directly contain samples and cannot contain other units).
+ * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer">LabKey Documentation</a>
+ * for further details.
+ * </p><p>
+ * A freezer may also have a parent hierarchy which defines the physical location of the freezer.
+ * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation">LabKey Documentation</a>
+ * for further details.
+ * </p><p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
- * Storage Unit Type, or Terminal Storage Location.
- * <p>
+ * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
+ * the {@link StorageRow} provided to the CreateCommand constructor.
+ * </p><p>
+ * The additional properties for the storage item being created can be provided as the "props" for the
+ * {@link StorageRow}. The specific set of props will differ for each storage item type:
+ * <ul>
+ *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location)</li>
+ *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status</li>
+ *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+ *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
+ *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+ * </ul>
+ * </p>
  * Examples:
  * <pre><code>
- *  // TODO ...
+ *  // May need to add CONTEXT_PATH for dev instances
+ *  Connection cn = new Connection("http://localhost:8080", user, password);
+ *
+ *  // Create Physical Location for freezer
+ *  StorageRow row = new StorageRow();
+ *  row.setType("Physical Location");
+ *  row.setProps(Map.of("name", "Building #1", "description", "Test physical location"));
+ *  CreateCommand cmd = new CreateCommand(row);
+ *  StorageCommandResponse response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer buildingRowId = response.getRowId();
+ *
+ *  // Create a freezer in Building #1
+ *  row = new StorageRow();
+ *  row.setType("Freezer");
+ *  row.setProps(Map.of("name", "Freezer A", "description", "Test freezer from API", "serialNumber", "ABC123", "locationId", buildingRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer freezerRowId = response.getRowId();
+ *
+ *  // Add two shelves to the freezer (note you can add additional non-terminal storage items to create
+ *  // the freezer hierarchy that matches your physical freezer)
+ *  row = new StorageRow();
+ *  row.setType("Shelf");
+ *  row.setProps(Map.of("name", "Shelf #1", "description", "Test shelf in Freezer A", "locationId", freezerRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer shelf1RowId = response.getRowId();
+ *
+ *  row = new StorageRow();
+ *  row.setType("Shelf");
+ *  row.setProps(Map.of("name", "Shelf #2", "description", "Another test shelf in Freezer A", "locationId", freezerRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer shelf2RowId = response.getRowId();
+ *
+ *  // Note that we are going to use an existing storage unit type that is part of the default set.
+ *  // You can create custom storage unit types using the CreateCommand with type = "Storage Unit Type".
+ *  SelectRowsCommand selectCommand = new SelectRowsCommand("inventory", "BoxType");
+ *  selectCommand.setColumns(Arrays.asList("RowId"));
+ *  selectCommand.addFilter(new Filter("Name", "96 Well Plate"));
+ *  SelectRowsResponse selectResponse = selectCommand.execute(connection, containerPath);
+ *  Integer plateTypeRowId = Integer.parseInt(selectResponse.getRows().get(0).get("RowId").toString());
+ *
+ *  // Add two plates to the shelf
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("name", "Plate #1", "description", "Test plate on Shelf #1", "typeId", plateTypeRowId, "locationId", shelf1RowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer plate1RowId = response.getRowId();
+ *
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("name", "Plate #2", "description", "Another test plate on Shelf #1", "typeId", plateTypeRowId, "locationId", shelf1RowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer plate2RowId = response.getRowId();
+ *
+ *  // Move Plate #2 to Shelf #2
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("description", "Plate moved to Shelf #2", "locationId", shelf2RowId));
+ *  row.setRowId(plate2RowId);
+ *  UpdateCommand updateCmd = new UpdateCommand(row);
+ *  updateCmd.execute(cn, "PROJECT_NAME");
+ *
+ *  // Delete the freezer, which will delete the full hierarchy of non-terminal and terminal storage locations
+ *  row = new StorageRow();
+ *  row.setType("Freezer");
+ *  row.setRowId(freezerRowId);
+ *  DeleteCommand deleteCmd = new DeleteCommand(row);
+ *  deleteCmd.execute(cn, "PROJECT_NAME");
  * </code></pre>
  * */
 public class CreateCommand extends BaseStorageCommand

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -1,22 +1,21 @@
 package org.labkey.remoteapi.storage;
 
 /**
- * <p>
  * Create a new LabKey Freezer Manager storage item that can be used in the creation of a freezer hierarchy.
  * Freezer hierarchies consist of a top level Freezer, which can have any combination of child non-terminal storage
  * locations (i.e. those that do not directly contain samples but can contain other units) and terminal storage
  * locations (i.e. units in the freezer that directly contain samples and cannot contain other units).
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer">LabKey Documentation</a>
  * for further details.
- * </p><p>
+ * <p>
  * A freezer may also have a parent hierarchy, which defines the physical location of the freezer.
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation">LabKey Documentation</a>
  * for further details.
- * </p><p>
+ * <p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
  * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
  * the {@link StorageRow} provided to the CreateCommand constructor.
- * </p><p>
+ * <p>
  * The additional properties for the storage item being created can be provided as the "props" for the
  * {@link StorageRow}. The specific set of props will differ for each storage item type:
  * <ul>
@@ -26,7 +25,7 @@ package org.labkey.remoteapi.storage;
  *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
  *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
  * </ul>
- * </p>
+ * <p>
  * Examples:
  * <pre><code>
  *  // May need to add CONTEXT_PATH for dev instances

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -2,14 +2,14 @@ package org.labkey.remoteapi.storage;
 
 /**
  * <p>
- * Create a new LabKey Freezer Manager storage item which can then be combined to create a freezer hierarchy.
- * Freezer hierarchies consist of a top level freezer which can have any combination of child non-terminal storage
+ * Create a new LabKey Freezer Manager storage item that can be used in the creation of a freezer hierarchy.
+ * Freezer hierarchies consist of a top level Freezer, which can have any combination of child non-terminal storage
  * locations (i.e. those that do not directly contain samples but can contain other units) and terminal storage
- * locations (i.e. units in the freezer which directly contain samples and cannot contain other units).
+ * locations (i.e. units in the freezer that directly contain samples and cannot contain other units).
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer">LabKey Documentation</a>
  * for further details.
  * </p><p>
- * A freezer may also have a parent hierarchy which defines the physical location of the freezer.
+ * A freezer may also have a parent hierarchy, which defines the physical location of the freezer.
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation">LabKey Documentation</a>
  * for further details.
  * </p><p>

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
@@ -1,15 +1,91 @@
 package org.labkey.remoteapi.storage;
 
 /**
+ * <p>
  * Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
  * freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
- * <p>
+ * </p><p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
- * Storage Unit Type, or Terminal Storage Location.
- * <p>
+ * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
+ * the {@link StorageRow} provided to the DeleteCommand constructor.
+ * </p><p>
+ * For the DeleteCommand, the "rowId" primary key value is required to be set within the {@link StorageRow}.
+ * This can be set directly in the "props" map or via the {@link StorageRow} setRowId() method.
+ * </p>
  * Examples:
  * <pre><code>
- *  // TODO ...
+ *  // May need to add CONTEXT_PATH for dev instances
+ *  Connection cn = new Connection("http://localhost:8080", user, password);
+ *
+ *  // Create Physical Location for freezer
+ *  StorageRow row = new StorageRow();
+ *  row.setType("Physical Location");
+ *  row.setProps(Map.of("name", "Building #1", "description", "Test physical location"));
+ *  CreateCommand cmd = new CreateCommand(row);
+ *  StorageCommandResponse response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer buildingRowId = response.getRowId();
+ *
+ *  // Create a freezer in Building #1
+ *  row = new StorageRow();
+ *  row.setType("Freezer");
+ *  row.setProps(Map.of("name", "Freezer A", "description", "Test freezer from API", "serialNumber", "ABC123", "locationId", buildingRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer freezerRowId = response.getRowId();
+ *
+ *  // Add two shelves to the freezer (note you can add additional non-terminal storage items to create
+ *  // the freezer hierarchy that matches your physical freezer)
+ *  row = new StorageRow();
+ *  row.setType("Shelf");
+ *  row.setProps(Map.of("name", "Shelf #1", "description", "Test shelf in Freezer A", "locationId", freezerRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer shelf1RowId = response.getRowId();
+ *
+ *  row = new StorageRow();
+ *  row.setType("Shelf");
+ *  row.setProps(Map.of("name", "Shelf #2", "description", "Another test shelf in Freezer A", "locationId", freezerRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer shelf2RowId = response.getRowId();
+ *
+ *  // Note that we are going to use an existing storage unit type that is part of the default set.
+ *  // You can create custom storage unit types using the CreateCommand with type = "Storage Unit Type".
+ *  SelectRowsCommand selectCommand = new SelectRowsCommand("inventory", "BoxType");
+ *  selectCommand.setColumns(Arrays.asList("RowId"));
+ *  selectCommand.addFilter(new Filter("Name", "96 Well Plate"));
+ *  SelectRowsResponse selectResponse = selectCommand.execute(connection, containerPath);
+ *  Integer plateTypeRowId = Integer.parseInt(selectResponse.getRows().get(0).get("RowId").toString());
+ *
+ *  // Add two plates to the shelf
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("name", "Plate #1", "description", "Test plate on Shelf #1", "typeId", plateTypeRowId, "locationId", shelf1RowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer plate1RowId = response.getRowId();
+ *
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("name", "Plate #2", "description", "Another test plate on Shelf #1", "typeId", plateTypeRowId, "locationId", shelf1RowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer plate2RowId = response.getRowId();
+ *
+ *  // Move Plate #2 to Shelf #2
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("description", "Plate moved to Shelf #2", "locationId", shelf2RowId));
+ *  row.setRowId(plate2RowId);
+ *  UpdateCommand updateCmd = new UpdateCommand(row);
+ *  updateCmd.execute(cn, "PROJECT_NAME");
+ *
+ *  // Delete the freezer, which will delete the full hierarchy of non-terminal and terminal storage locations
+ *  row = new StorageRow();
+ *  row.setType("Freezer");
+ *  row.setRowId(freezerRowId);
+ *  DeleteCommand deleteCmd = new DeleteCommand(row);
+ *  deleteCmd.execute(cn, "PROJECT_NAME");
  * </code></pre>
  * */
 public class DeleteCommand extends BaseStorageCommand

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
@@ -1,0 +1,25 @@
+package org.labkey.remoteapi.storage;
+
+/**
+ * Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
+ * freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
+ * <p>
+ * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+ * Storage Unit Type, or Terminal Storage Location.
+ * <p>
+ * Examples:
+ * <pre><code>
+ *  // TODO ...
+ * </code></pre>
+ * */
+public class DeleteCommand extends BaseStorageCommand
+{
+    /**
+     * Constructs a new DeleteCommand for the given {@link StorageRow}.
+     * @param storageRow The details about the storage row to be updated.
+     */
+    public DeleteCommand(StorageRow storageRow)
+    {
+        super("delete", storageRow);
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
@@ -1,18 +1,17 @@
 package org.labkey.remoteapi.storage;
 
 /**
- * <p>
  * Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
  * freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
  * Samples in the deleted freezer location(s) will not be deleted but will be removed from storage.
- * </p><p>
+ * <p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
  * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
  * the {@link StorageRow} provided to the DeleteCommand constructor.
- * </p><p>
+ * <p>
  * For the DeleteCommand, the "rowId" primary key value is required to be set within the {@link StorageRow}.
  * This can be set directly in the "props" map or via the {@link StorageRow} setRowId() method.
- * </p>
+ * <p>
  * Examples:
  * <pre><code>
  *  // May need to add CONTEXT_PATH for dev instances

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/DeleteCommand.java
@@ -4,6 +4,7 @@ package org.labkey.remoteapi.storage;
  * <p>
  * Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
  * freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
+ * Samples in the deleted freezer location(s) will not be deleted but will be removed from storage.
  * </p><p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
  * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/StorageCommandResponse.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/StorageCommandResponse.java
@@ -1,0 +1,62 @@
+package org.labkey.remoteapi.storage;
+
+import org.json.simple.JSONObject;
+import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.CommandResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Response object used for the storage {@link CreateCommand}, {@link UpdateCommand}, and {@link DeleteCommand}.
+ * The response object will include a string message and a data object with the
+ * properties from the relevant storage item from the command.
+ */
+public class StorageCommandResponse extends CommandResponse
+{
+    private String _message;
+    private Map<String, Object> _data;
+
+    /**
+     * Constructs a new StorageCommandResponse, initialized with the provided
+     * response text and status code.
+     *
+     * @param text          The response text
+     * @param statusCode    The HTTP status code
+     * @param contentType   The response content type
+     * @param json          The parsed JSONObject (or null if JSON was not returned).
+     * @param sourceCommand A copy of the command that created this response
+     */
+    public StorageCommandResponse(String text, int statusCode, String contentType, JSONObject json, Command sourceCommand)
+    {
+        super(text, statusCode, contentType, json, sourceCommand);
+        _message = json.get("message").toString();
+        _data = new HashMap<>((JSONObject)json.get("data"));
+    }
+
+    /**
+     * Returns the success message for the command.
+     * @return The success message string.
+     */
+    public String getMessage()
+    {
+        return _message;
+    }
+
+    /**
+     * Returns the data object with properties from the newly created storage item.
+     * @return A map of the key value pairs for the storage item.
+     */
+    public Map<String, Object> getData()
+    {
+        return _data;
+    }
+
+    public Integer getRowId()
+    {
+        if (getData().containsKey("rowId"))
+            return Integer.parseInt(getData().get("rowId").toString());
+
+        return null;
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/StorageItemTypes.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/StorageItemTypes.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.remoteapi.storage;
+
+public enum StorageItemTypes
+{
+    PhysicalLocation("Physical Location"),
+    Freezer("Freezer"),
+    Shelf("Shelf"),
+    Rack("Rack"),
+    Canister("Canister"),
+    StorageUnitType("Storage Unit Type"),
+    TerminalStorageLocation("Terminal Storage Location");
+
+    private final String _title;
+
+    StorageItemTypes(String title)
+    {
+        _title = title;
+    }
+
+    public String getTitle()
+    {
+        return _title;
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/StorageRow.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/StorageRow.java
@@ -15,6 +15,13 @@ public class StorageRow
         return _type;
     }
 
+    /**
+     * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+     * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
+     * the {@link StorageRow} provided to the {@link CreateCommand}, {@link UpdateCommand}, or {@link DeleteCommand}
+     * constructor.
+     * @param type Type value for the given storage item/row
+     */
     public void setType(String type)
     {
         _type = type;
@@ -25,22 +32,33 @@ public class StorageRow
         return _props;
     }
 
+    /**
+     * The additional properties for the storage item being created/updated can be provided as the "props" for the
+     * {@link StorageRow}. The specific set of props will differ for each storage item type:
+     * <ul>
+     *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location)</li>
+     *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status</li>
+     *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+     *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
+     *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+     * </ul>
+     * @param props Map of properties for the given storage item/row
+     */
     public void setProps(Map<String, Object> props)
     {
         _props = props;
     }
 
+    /**
+     * For the {@link UpdateCommand} and {@link DeleteCommand}, the "rowId" primary key value is required to be set.
+     * This helper method will put the rowId value into the "props" for this {@link StorageRow}.
+     * @param rowId Integer rowId primary key for the given storage item/row
+     */
     public void setRowId(Integer rowId)
     {
         Map<String, Object> props = new HashMap<>(_props);
         props.put("rowId", rowId);
         setProps(props);
-    }
-
-    public Map<String, Object> addProp(String key, Object value)
-    {
-        _props.put(key, value);
-        return _props;
     }
 
     public JSONObject toJsonObject()

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/StorageRow.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/StorageRow.java
@@ -1,0 +1,53 @@
+package org.labkey.remoteapi.storage;
+
+import org.json.simple.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StorageRow
+{
+    private String _type;
+    private Map<String, Object> _props = new HashMap<>();
+
+    public String getType()
+    {
+        return _type;
+    }
+
+    public void setType(String type)
+    {
+        _type = type;
+    }
+
+    public Map<String, Object> getProps()
+    {
+        return _props;
+    }
+
+    public void setProps(Map<String, Object> props)
+    {
+        _props = props;
+    }
+
+    public void setRowId(Integer rowId)
+    {
+        Map<String, Object> props = new HashMap<>(_props);
+        props.put("rowId", rowId);
+        setProps(props);
+    }
+
+    public Map<String, Object> addProp(String key, Object value)
+    {
+        _props.put(key, value);
+        return _props;
+    }
+
+    public JSONObject toJsonObject()
+    {
+        JSONObject result = new JSONObject();
+        result.put("type", this.getType());
+        result.put("props", new JSONObject(this.getProps()));
+        return result;
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/StorageRow.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/StorageRow.java
@@ -5,14 +5,18 @@ import org.json.simple.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The storage properties object used for the storage {@link CreateCommand}, {@link UpdateCommand}, and {@link DeleteCommand}.
+ * This object will define the type of the item along with the specific properties for that storage item.
+ */
 public class StorageRow
 {
-    private String _type;
+    private StorageItemTypes _type;
     private Map<String, Object> _props = new HashMap<>();
 
     public String getType()
     {
-        return _type;
+        return _type.getTitle();
     }
 
     /**
@@ -22,7 +26,7 @@ public class StorageRow
      * constructor.
      * @param type Type value for the given storage item/row
      */
-    public void setType(String type)
+    public void setType(StorageItemTypes type)
     {
         _type = type;
     }

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/UpdateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/UpdateCommand.java
@@ -1,14 +1,100 @@
 package org.labkey.remoteapi.storage;
 
 /**
+ * <p>
  * Update an existing LabKey Freezer Manager storage item to change its properties or location within the freezer hierarchy.
- * <p>
+ * </p><p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
- * Storage Unit Type, or Terminal Storage Location.
- * <p>
+ * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
+ * the {@link StorageRow} provided to the UpdateCommand constructor.
+ * </p><p>
+ * The additional properties for the storage item being updated can be provided as the "props" for the
+ * {@link StorageRow}. The specific set of props will differ for each storage item type:
+ * <ul>
+ *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location)</li>
+ *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status</li>
+ *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+ *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
+ *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+ * </ul>
+ * </p><p>
+ * For the UpdateCommand, the "rowId" primary key value is required to be set within the {@link StorageRow}.
+ * This can be set directly in the "props" map or via the {@link StorageRow} setRowId() method.
+ * </p>
  * Examples:
  * <pre><code>
- *  // TODO ...
+ *  // May need to add CONTEXT_PATH for dev instances
+ *  Connection cn = new Connection("http://localhost:8080", user, password);
+ *
+ *  // Create Physical Location for freezer
+ *  StorageRow row = new StorageRow();
+ *  row.setType("Physical Location");
+ *  row.setProps(Map.of("name", "Building #1", "description", "Test physical location"));
+ *  CreateCommand cmd = new CreateCommand(row);
+ *  StorageCommandResponse response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer buildingRowId = response.getRowId();
+ *
+ *  // Create a freezer in Building #1
+ *  row = new StorageRow();
+ *  row.setType("Freezer");
+ *  row.setProps(Map.of("name", "Freezer A", "description", "Test freezer from API", "serialNumber", "ABC123", "locationId", buildingRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer freezerRowId = response.getRowId();
+ *
+ *  // Add two shelves to the freezer (note you can add additional non-terminal storage items to create
+ *  // the freezer hierarchy that matches your physical freezer)
+ *  row = new StorageRow();
+ *  row.setType("Shelf");
+ *  row.setProps(Map.of("name", "Shelf #1", "description", "Test shelf in Freezer A", "locationId", freezerRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer shelf1RowId = response.getRowId();
+ *
+ *  row = new StorageRow();
+ *  row.setType("Shelf");
+ *  row.setProps(Map.of("name", "Shelf #2", "description", "Another test shelf in Freezer A", "locationId", freezerRowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer shelf2RowId = response.getRowId();
+ *
+ *  // Note that we are going to use an existing storage unit type that is part of the default set.
+ *  // You can create custom storage unit types using the CreateCommand with type = "Storage Unit Type".
+ *  SelectRowsCommand selectCommand = new SelectRowsCommand("inventory", "BoxType");
+ *  selectCommand.setColumns(Arrays.asList("RowId"));
+ *  selectCommand.addFilter(new Filter("Name", "96 Well Plate"));
+ *  SelectRowsResponse selectResponse = selectCommand.execute(connection, containerPath);
+ *  Integer plateTypeRowId = Integer.parseInt(selectResponse.getRows().get(0).get("RowId").toString());
+ *
+ *  // Add two plates to the shelf
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("name", "Plate #1", "description", "Test plate on Shelf #1", "typeId", plateTypeRowId, "locationId", shelf1RowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer plate1RowId = response.getRowId();
+ *
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("name", "Plate #2", "description", "Another test plate on Shelf #1", "typeId", plateTypeRowId, "locationId", shelf1RowId));
+ *  cmd = new CreateCommand(row);
+ *  response = cmd.execute(cn, "PROJECT_NAME");
+ *  Integer plate2RowId = response.getRowId();
+ *
+ *  // Move Plate #2 to Shelf #2
+ *  row = new StorageRow();
+ *  row.setType("Terminal Storage Location");
+ *  row.setProps(Map.of("description", "Plate moved to Shelf #2", "locationId", shelf2RowId));
+ *  row.setRowId(plate2RowId);
+ *  UpdateCommand updateCmd = new UpdateCommand(row);
+ *  updateCmd.execute(cn, "PROJECT_NAME");
+ *
+ *  // Delete the freezer, which will delete the full hierarchy of non-terminal and terminal storage locations
+ *  row = new StorageRow();
+ *  row.setType("Freezer");
+ *  row.setRowId(freezerRowId);
+ *  DeleteCommand deleteCmd = new DeleteCommand(row);
+ *  deleteCmd.execute(cn, "PROJECT_NAME");
  * </code></pre>
  * */
 public class UpdateCommand extends BaseStorageCommand

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/UpdateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/UpdateCommand.java
@@ -1,13 +1,12 @@
 package org.labkey.remoteapi.storage;
 
 /**
- * <p>
  * Update an existing LabKey Freezer Manager storage item to change its properties or location within the freezer hierarchy.
- * </p><p>
+ * <p>
  * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
  * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
  * the {@link StorageRow} provided to the UpdateCommand constructor.
- * </p><p>
+ * <p>
  * The additional properties for the storage item being updated can be provided as the "props" for the
  * {@link StorageRow}. The specific set of props will differ for each storage item type:
  * <ul>
@@ -17,10 +16,10 @@ package org.labkey.remoteapi.storage;
  *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
  *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
  * </ul>
- * </p><p>
+ * <p>
  * For the UpdateCommand, the "rowId" primary key value is required to be set within the {@link StorageRow}.
  * This can be set directly in the "props" map or via the {@link StorageRow} setRowId() method.
- * </p>
+ * <p>
  * Examples:
  * <pre><code>
  *  // May need to add CONTEXT_PATH for dev instances

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/UpdateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/UpdateCommand.java
@@ -1,0 +1,24 @@
+package org.labkey.remoteapi.storage;
+
+/**
+ * Update an existing LabKey Freezer Manager storage item to change its properties or location within the freezer hierarchy.
+ * <p>
+ * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+ * Storage Unit Type, or Terminal Storage Location.
+ * <p>
+ * Examples:
+ * <pre><code>
+ *  // TODO ...
+ * </code></pre>
+ * */
+public class UpdateCommand extends BaseStorageCommand
+{
+    /**
+     * Constructs a new UpdateCommand for the given {@link StorageRow}.
+     * @param storageRow The details about the storage row to be updated.
+     */
+    public UpdateCommand(StorageRow storageRow)
+    {
+        super("update", storageRow);
+    }
+}

--- a/labkey-client-api/src/org/labkey/remoteapi/test/MS2SearchClient.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/test/MS2SearchClient.java
@@ -16,14 +16,16 @@
 package org.labkey.remoteapi.test;
 
 import au.com.bytecode.opencsv.CSVReader;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.assay.Batch;
+import org.labkey.remoteapi.assay.Data;
+import org.labkey.remoteapi.assay.Run;
+import org.labkey.remoteapi.assay.SaveAssayBatchCommand;
+import org.labkey.remoteapi.ms2.StartSearchCommand;
 
 import java.io.*;
 import java.util.*;
-
-import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.assay.*;
-import org.labkey.remoteapi.ms2.StartSearchCommand;
 
 /**
  * Demo code that accepts one or more CSV files on the command line. It creates assay runs to hold the metadata
@@ -59,10 +61,10 @@ public class MS2SearchClient
     /** Simple bean class to hold the values that uniquely identify the files to be submitted in one search */
     private static class SearchInfo
     {
-        private String _sample;
-        private String _protocol;
-        private String _folder;
-        private String _path;
+        private final String _sample;
+        private final String _protocol;
+        private final String _folder;
+        private final String _path;
 
         private SearchInfo(String sample, String protocol, String folder, String path)
         {
@@ -348,7 +350,7 @@ public class MS2SearchClient
         run.setName(fileName);
         run.getProperties().putAll(runProperties);
         batch.getRuns().add(run);
-        List<Data> outputFiles = new ArrayList<Data>();
+        List<Data> outputFiles = new ArrayList<>();
         Data data = new Data();
         data.setAbsolutePath(path + File.separator + fileName);
         outputFiles.add(data);
@@ -356,7 +358,7 @@ public class MS2SearchClient
     }
 
     /** Finds a column by name given the column headers */
-    private static int findIndex(String headers[], String propertyName)
+    private static int findIndex(String[] headers, String propertyName)
     {
         for (int i = 0; i < headers.length; i++)
         {

--- a/labkey-client-api/src/org/labkey/remoteapi/test/SaveAssayBatchDemo.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/test/SaveAssayBatchDemo.java
@@ -108,7 +108,7 @@ public class SaveAssayBatchDemo
         batch.getRuns().add(run);
 
         // Add each of the files to the run
-        List<Data> inputFiles = new ArrayList<Data>();
+        List<Data> inputFiles = new ArrayList<>();
         Data data = new Data();
         data.setAbsolutePath(fileName);
         System.out.println("Adding usage \"" + description + " \" for file \"" + fileName + "\"");


### PR DESCRIPTION
#### Rationale
In the related PR for this epic we added a new StorageController with actions for create/update/delete of freezer hierarchy items (i.e. freezer physical locations, freezers, locations within the freezer, storage unit types, and terminal storage locations). This PR adds a new namespace (storage) to the Java API with commands for calling those StorageController actions.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/542
* https://github.com/LabKey/inventory/pull/545
* https://github.com/LabKey/sampleManagement/pull/1221

#### Changes
* storage namespace with CreateCommand, UpdateCommand, DeleteCommand
* JavaDocs and examples
