### PR TITLE
Issue 46321: Remove redundant `lib` directory containing jar files

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version TBD
+*Released*: TBD
+* Remove `lib` directory from `fatJar` in favor of pulling dependencies via the published pom files when needed
+* Remove artifactory plugin since we use the maven `publish` command now
+
 ## version 3.1.0
 *Released*: 20 September 2022
 * Add support for creating Freezer Manager freezer hierarchies via StorageController APIs (earliest compatible LabKey Server version: 22.10.0)

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## version TBD
 *Released*: TBD
-* Remove `lib` directory from `fatJar` in favor of pulling dependencies via the published pom files when needed
+* Issue 46321: Remove `lib` directory from `fatJar` in favor of pulling dependencies via the published pom files when needed
 * Remove artifactory plugin since we use the maven `publish` command now
 
 ## version 3.1.0

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -56,8 +56,6 @@ dependencies {
             {
                 // exclude this because it gets in the way of our own JSON object implementations from server/api
                 exclude group: "org.json", module:"json"
-                // exclude this since it's not required for non-test usage of this dependency
-                exclude group: "junit", module:"junit"
             }
     api "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"
     api "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "3.2.0-skinnierFatJar-SNAPSHOT"
+version "3.2.0-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -18,14 +18,6 @@ buildscript {
     }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-        // N.B.  We use the "old-fashioned" way of applying the artifactory plugin because if we use
-        // the plugins block below and specify a version number, the following error happens if building
-        // in conjunction with LabKey server (i.e., when including this project in the server's build.gradle
-        //    Error resolving plugin [id: 'com.jfrog.artifactory', version: '4.13.0', apply: false]
-        //    > Plugin request for plugin already on the classpath must not include a version
-        // We could instead include the plugin without a version number, which would work until
-        // some change in the latest version of the plugin came along that we aren't compatible with.
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:${artifactoryPluginVersion}"
     }
 }
 
@@ -57,7 +49,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "3.2.0-SNAPSHOT"
+version "3.2.0-removeBuildInfoPlugin-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")
@@ -224,37 +216,6 @@ project.publishing {
                 }
             }
         }
-    }
-    apply plugin: 'com.jfrog.artifactory'
-    artifactory {
-        contextUrl = "${artifactory_contextUrl}"
-        //The base Artifactory URL if not overridden by the publisher/resolver
-        publish {
-            repository {
-                repoKey = BuildUtils.getRepositoryKey(project)
-                if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
-                {
-                    username = artifactory_user
-                    password = artifactory_password
-                }
-                maven = true
-            }
-            defaults {
-                publishBuildInfo = false
-                publishPom = true
-                publishIvy = false
-            }
-        }
-    }
-
-    project.artifactoryPublish {
-        project.tasks.each {
-            if (it instanceof Jar)
-            {
-                dependsOn it
-            }
-        }
-        publications('libs')
     }
 }
 

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -49,13 +49,15 @@ repositories {
 
 group "org.labkey.api"
 
-version "3.2.0-removeBuildInfoPlugin-SNAPSHOT"
+version "3.2.0-skinnierFatJar-SNAPSHOT"
 
 dependencies {
     api ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")
             {
                 // exclude this because it gets in the way of our own JSON object implementations from server/api
                 exclude group: "org.json", module:"json"
+                // exclude this since it's not required for non-test usage of this dependency
+                exclude group: "junit", module:"junit"
             }
     api "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"
     api "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
@@ -116,10 +118,6 @@ project.task("fatJar",
                 jar.setArchiveVersion(project.version)
                 jar.archiveClassifier.set(LabKey.FAT_JAR_CLASSIFIER)
                 jar.dependsOn project.tasks.jar
-                jar.into('lib') {
-                    from tasks.jar
-                    from configurations.runtimeClasspath
-                }
         }
 )
 

--- a/labkey-client-api/gradle.properties
+++ b/labkey-client-api/gradle.properties
@@ -7,7 +7,6 @@ artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 sourceCompatibility=17
 targetCompatibility=17
 
-artifactoryPluginVersion=4.21.0
 gradlePluginsVersion=1.35.0
 
 commonsCodecVersion=1.15


### PR DESCRIPTION
#### Rationale
[Issue 46321](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46321)

#### Related Pull Requests

#### Changes
* Remove lib directory from fatJar.
* Remove artifactory buildInfo plugin since we have never used this buildInfo 