### PR TITLE
Fix createURI for servers without a context path

### DIFF
--- a/labkey-client-api/src/org/labkey/remoteapi/Command.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Command.java
@@ -480,10 +480,10 @@ public class Command<ResponseType extends CommandResponse>
         if (null != folderPath && folderPath.length() > 0)
         {
             String folderPathNormalized = folderPath.replace('\\', '/');
+            if (folderPathNormalized.charAt(0) == '/') // strip leading slash
+                folderPathNormalized = folderPathNormalized.substring(1);
             if (path.charAt(path.length() - 1) != '/')
                 path.append('/');
-            else if (folderPathNormalized.charAt(0) == '/') // strip leading slash
-                folderPathNormalized = folderPathNormalized.substring(1);
             path.append(folderPathNormalized);
         }
 

--- a/labkey-client-api/src/org/labkey/remoteapi/Command.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/Command.java
@@ -480,8 +480,10 @@ public class Command<ResponseType extends CommandResponse>
         if (null != folderPath && folderPath.length() > 0)
         {
             String folderPathNormalized = folderPath.replace('\\', '/');
-            if (folderPathNormalized.charAt(0) != '/' && path.charAt(path.length() - 1) != '/')
+            if (path.charAt(path.length() - 1) != '/')
                 path.append('/');
+            else if (folderPathNormalized.charAt(0) == '/') // strip leading slash
+                folderPathNormalized = folderPathNormalized.substring(1);
             path.append(folderPathNormalized);
         }
 


### PR DESCRIPTION
#### Rationale
If you attempt to use the remote API against a server with no context path (e.g. `http://localhost:8080` instead of `http://localhost:8080/labkey`), it ends up building a URI path with double slashes in some scenarios. This triggers an exception in the URI builder:
```
java.lang.IllegalArgumentException: URI path begins with multiple slashes
	at org.apache.hc.core5.util.Args.check(Args.java:41)
	at org.apache.hc.core5.http.message.BasicHttpRequest.setUri(BasicHttpRequest.java:281)
	at org.apache.hc.core5.http.message.BasicHttpRequest.<init>(BasicHttpRequest.java:123)
	at org.apache.hc.core5.http.message.BasicClassicHttpRequest.<init>(BasicClassicHttpRequest.java:91)
	at org.apache.hc.client5.http.classic.methods.HttpUriRequestBase.<init>(HttpUriRequestBase.java:45)
	at org.apache.hc.client5.http.classic.methods.HttpGet.<init>(HttpGet.java:50)
	at org.labkey.remoteapi.Command.createRequest(Command.java:462)
```

#### Related Pull Requests
* #42 

#### Changes
* Strip leading slash from folder path
