### PR TITLE
Add Primary Storage as a StorageItemType

### DIFF
--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 4.1.0-SNAPSHOT
-*Released*: TBD
+## version 4.1.0
+*Released*: 15 December 2022
 * Migrate internal HTTP handling to use Apache HttpClient 5.2
 * Generate and execute path-first URLs
 * Add PrimaryStorage a new StorageItemTypes for non-freezer storage

--- a/labkey-client-api/CHANGELOG.md
+++ b/labkey-client-api/CHANGELOG.md
@@ -4,6 +4,7 @@
 *Released*: TBD
 * Migrate internal HTTP handling to use Apache HttpClient 5.2
 * Generate and execute path-first URLs
+* Add PrimaryStorage a new StorageItemTypes for non-freezer storage
 
 ## version 4.0.0
 *Released*: 26 October 2022

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.1.0-SNAPSHOT"
+version "4.1.0-freezerToStorage-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/labkey-client-api/build.gradle
+++ b/labkey-client-api/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.1.0-freezerToStorage-SNAPSHOT"
+version "4.2.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -20,8 +20,8 @@ package org.labkey.remoteapi.storage;
  * The additional properties for the storage item being created can be provided as the "props" for the
  * {@link StorageRow}. The specific set of props will differ for each storage item type:
  * <ul>
- *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location)</li>
- *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status</li>
+ *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location), temperatureControlled (boolean)</li>
+ *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status, temperatureControlled (boolean)</li>
  *     <li>Primary Storage: name, description, locationId (rowId of the parent Physical Location)</li>
  *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
  *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -1,18 +1,19 @@
 package org.labkey.remoteapi.storage;
 
 /**
- * Create a new LabKey Freezer Manager storage item that can be used in the creation of a freezer hierarchy.
- * Freezer hierarchies consist of a top level Freezer, which can have any combination of child non-terminal storage
- * locations (i.e. those that do not directly contain samples but can contain other units) and terminal storage
- * locations (i.e. units in the freezer that directly contain samples and cannot contain other units).
+ * Create a new LabKey Freezer Manager storage item that can be used in the creation of a storage hierarchy.
+ * Storage hierarchies consist of a top level Freezer or Primary Storage, which can have any combination of
+ * child non-terminal storage locations (i.e. those that do not directly contain samples but can contain other
+ * units) and terminal storage locations (i.e. units in the freezer that directly contain samples and cannot contain
+ * other units).
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer">LabKey Documentation</a>
  * for further details.
  * <p>
- * A freezer may also have a parent hierarchy, which defines the physical location of the freezer.
+ * A storage location may also have a parent hierarchy, which defines the physical location of the freezer.
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation">LabKey Documentation</a>
  * for further details.
  * <p>
- * Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+ * Storage items can be of the following types: Physical Location, Freezer, Primary Storage, Shelf, Rack, Canister,
  * Storage Unit Type, or Terminal Storage Location. One of these values must be set as the "type" for
  * the {@link StorageRow} provided to the CreateCommand constructor.
  * <p>
@@ -21,6 +22,7 @@ package org.labkey.remoteapi.storage;
  * <ul>
  *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location)</li>
  *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status</li>
+ *     <li>Primary Storage: name, description, locationId (rowId of the parent Physical Location)</li>
  *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
  *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
  *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -3,13 +3,13 @@ package org.labkey.remoteapi.storage;
 /**
  * Create a new LabKey Freezer Manager storage item that can be used in the creation of a storage hierarchy.
  * Storage hierarchies consist of a top level Freezer or Primary Storage, which can have any combination of
- * child non-terminal storage locations (i.e. those that do not directly contain samples but can contain other
- * units) and terminal storage locations (i.e. units in the freezer that directly contain samples and cannot contain
+ * child non-terminal storage locations (i.e., those that do not directly contain samples but can contain other
+ * units) and terminal storage locations (i.e., units in the storage location that directly contain samples and cannot contain
  * other units).
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer">LabKey Documentation</a>
  * for further details.
  * <p>
- * A storage location may also have a parent hierarchy, which defines the physical location of the freezer.
+ * A storage location may also have a parent hierarchy, which defines the physical location of the storage location.
  * See the <a href="https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation">LabKey Documentation</a>
  * for further details.
  * <p>
@@ -23,9 +23,9 @@ package org.labkey.remoteapi.storage;
  *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location), temperatureControlled (boolean)</li>
  *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status, temperatureControlled (boolean)</li>
  *     <li>Primary Storage: name, description, locationId (rowId of the parent Physical Location)</li>
- *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+ *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer, primary storage, or Shelf/Rack/Canister)</li>
  *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
- *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)</li>
+ *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer, primary storage or Shelf/Rack/Canister)</li>
  * </ul>
  * <p>
  * Examples:

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/CreateCommand.java
@@ -20,9 +20,9 @@ package org.labkey.remoteapi.storage;
  * The additional properties for the storage item being created can be provided as the "props" for the
  * {@link StorageRow}. The specific set of props will differ for each storage item type:
  * <ul>
- *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location), temperatureControlled (boolean)</li>
+ *     <li>Physical Location: name, description, locationId (rowId of the parent Physical Location)</li>
  *     <li>Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status, temperatureControlled (boolean)</li>
- *     <li>Primary Storage: name, description, locationId (rowId of the parent Physical Location)</li>
+ *     <li>Primary Storage: name, description, locationId (rowId of the parent Physical Location), temperatureControlled (boolean)</li>
  *     <li>Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer, primary storage, or Shelf/Rack/Canister)</li>
  *     <li>Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")</li>
  *     <li>Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer, primary storage or Shelf/Rack/Canister)</li>

--- a/labkey-client-api/src/org/labkey/remoteapi/storage/StorageItemTypes.java
+++ b/labkey-client-api/src/org/labkey/remoteapi/storage/StorageItemTypes.java
@@ -19,6 +19,7 @@ public enum StorageItemTypes
 {
     PhysicalLocation("Physical Location"),
     Freezer("Freezer"),
+    PrimaryStorage("Primary Storage"),
     Shelf("Shelf"),
     Rack("Rack"),
     Canister("Canister"),


### PR DESCRIPTION
#### Rationale
We want to make it more clear within the application and our APIs that our storage management capabilities can support temperature-controlled as well as room-temperature storage. Thus we're updating the language in the applications to refer to the primary storage units more generically as "Storage" instead of "Freezers".

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1055
- https://github.com/LabKey/inventory/pull/648

#### Changes
* Add `PrimaryStorage` as a new `StorageItemTypes` equivalent to `Freezer` from room-temp storage
