### PR TITLE
Issue 47030: Have the Java SelectRowsCommand use POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 4.3.0-SNAPSHOT
+## version 4.4.0-SNAPSHOT
 *Released*: TBD
+
+## version 4.3.0
+*Released*: 11 January 2023
+* [Issue 47030](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47030): Switch `SelectRowsCommand` and `NAbRunsCommand` to always use POST
+* Add support for `includeTotalCount`, `includeMetadata`, and `ignoreFilter` flags to `BaseQueryCommand` and reconcile duplicate parameter handling code vs. SelectRowsCommand
+* Add support for `includeTitle` and `includeViewDataUrl` flags to `GetQueriesCommand`
 
 ## version 4.2.0
 *Released*: 10 January 2023

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.3.0-SNAPSHOT"
+version "4.4.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.3.0-47030-SNAPSHOT"
+version "4.4.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.4.0-SNAPSHOT"
+version "4.3.0-47030-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/src/org/labkey/remoteapi/query/BaseQueryCommand.java
+++ b/src/org/labkey/remoteapi/query/BaseQueryCommand.java
@@ -15,15 +15,15 @@
  */
 package org.labkey.remoteapi.query;
 
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class BaseQueryCommand<ResponseType extends CommandResponse> extends Command<ResponseType>
+public abstract class BaseQueryCommand<ResponseType extends CommandResponse> extends PostCommand<ResponseType>
 {
     protected int _maxRows = -1;
     protected int _offset = 0;
@@ -238,19 +238,23 @@ public abstract class BaseQueryCommand<ResponseType extends CommandResponse> ext
         Map<String, Object> params = super.getParameters();
 
         if (getOffset() > 0)
-            params.put("offset", getOffset());
+            params.put("query.offset", getOffset());
+
         if (getMaxRows() >= 0)
-            params.put("maxRows", getMaxRows());
-        if(null != getSorts() && getSorts().size() > 0)
+            params.put("query.maxRows", getMaxRows());
+        else
+            params.put("query.showRows", "all");
+
+        if (null != getSorts() && getSorts().size() > 0)
             params.put("query.sort", Sort.getSortQueryStringParam(getSorts()));
 
-        if(null != getFilters())
+        if (null != getFilters())
         {
             for(Filter filter : getFilters())
                 params.put("query." + filter.getQueryStringParamName(), filter.getQueryStringParamValue());
         }
 
-        if(getContainerFilter() != null)
+        if (getContainerFilter() != null)
             params.put("containerFilter", getContainerFilter().name());
 
         for (Map.Entry<String, String> entry : getQueryParameters().entrySet())

--- a/src/org/labkey/remoteapi/query/BaseQueryCommand.java
+++ b/src/org/labkey/remoteapi/query/BaseQueryCommand.java
@@ -31,6 +31,9 @@ public abstract class BaseQueryCommand<ResponseType extends CommandResponse> ext
     protected List<Filter> _filters;
     protected ContainerFilter _containerFilter;
     private Map<String, String> _queryParameters = new HashMap<>();
+    private boolean _ignoreFilter = false;
+    private boolean _includeMetadata = true;
+    private boolean _includeTotalCount = true;
 
     public BaseQueryCommand(BaseQueryCommand<ResponseType> source)
     {
@@ -213,6 +216,48 @@ public abstract class BaseQueryCommand<ResponseType extends CommandResponse> ext
         _containerFilter = containerFilter;
     }
 
+    public boolean isIgnoreFilter()
+    {
+        return _ignoreFilter;
+    }
+
+    /**
+     * Pass true to ignore any filter that may be part of the chosen view. Defaults to false.
+     * @param ignoreFilter Set to 'true' to ignore the view filter.
+     */
+    public void setIgnoreFilter(boolean ignoreFilter)
+    {
+        _ignoreFilter = ignoreFilter;
+    }
+
+    public boolean isIncludeMetadata()
+    {
+        return _includeMetadata;
+    }
+
+    /**
+     * Pass false to omit metadata for the selected columns. Defaults to true.
+     * @param includeMetadata Set to 'false' to omit column metadata.
+     */
+    public void setIncludeMetadata(boolean includeMetadata)
+    {
+        _includeMetadata = includeMetadata;
+    }
+
+    public boolean isIncludeTotalCount()
+    {
+        return _includeTotalCount;
+    }
+
+    /**
+     * Pass false to omit total count from the response. Default is true.
+     * @param includeTotalCount Set to 'false' to omit total count.
+     */
+    public void setIncludeTotalCount(boolean includeTotalCount)
+    {
+        _includeTotalCount = includeTotalCount;
+    }
+
     /**
      @return Map of name (string)/value pairs for the values of parameters if the SQL references underlying queries
      that are parameterized.
@@ -261,6 +306,15 @@ public abstract class BaseQueryCommand<ResponseType extends CommandResponse> ext
         {
             params.put("query.param." + entry.getKey(), entry.getValue());
         }
+
+        if (!isIncludeTotalCount())
+            params.put("includeTotalCount", isIncludeTotalCount());
+
+        if (!isIncludeMetadata())
+            params.put("includeMetadata", isIncludeMetadata());
+
+        if (isIgnoreFilter())
+            params.put("query.ignoreFilter", isIgnoreFilter());
 
         return params;
     }

--- a/src/org/labkey/remoteapi/query/GetQueriesCommand.java
+++ b/src/org/labkey/remoteapi/query/GetQueriesCommand.java
@@ -27,8 +27,10 @@ import java.util.Map;
 public class GetQueriesCommand extends Command<GetQueriesResponse>
 {
     private String _schemaName;
-    private boolean _includeUserQueries = true;
     private boolean _includeColumns = true;
+    private boolean _includeTitle = true;
+    private boolean _includeUserQueries = true;
+    private boolean _includeViewDataUrl = true;
 
     /**
      * Constructs the command given a particular schema name.
@@ -50,21 +52,6 @@ public class GetQueriesCommand extends Command<GetQueriesResponse>
         _schemaName = schemaName;
     }
 
-    public boolean isIncludeUserQueries()
-    {
-        return _includeUserQueries;
-    }
-
-    /**
-     * Pass false to this method to omit user-defined queries from the results. By default,
-     * user-defined queries are included.
-     * @param includeUserQueries Set to false to omit user-defined queries.
-     */
-    public void setIncludeUserQueries(boolean includeUserQueries)
-    {
-        _includeUserQueries = includeUserQueries;
-    }
-
     public boolean isIncludeColumns()
     {
         return _includeColumns;
@@ -80,6 +67,50 @@ public class GetQueriesCommand extends Command<GetQueriesResponse>
         _includeColumns = includeColumns;
     }
 
+    public boolean isIncludeTitle()
+    {
+        return _includeTitle;
+    }
+
+    /**
+     * Pass false to omit custom query titles. Titles will be returned, but their values will be identical to names.
+     * Default is true.
+     * @param includeTitle 'false' to omit custom query titles.
+     */
+    public void setIncludeTitle(boolean includeTitle)
+    {
+        _includeTitle = includeTitle;
+    }
+
+    public boolean isIncludeUserQueries()
+    {
+        return _includeUserQueries;
+    }
+
+    /**
+     * Pass false to this method to omit user-defined queries from the results. By default,
+     * user-defined queries are included.
+     * @param includeUserQueries Set to 'false' to omit user-defined queries.
+     */
+    public void setIncludeUserQueries(boolean includeUserQueries)
+    {
+        _includeUserQueries = includeUserQueries;
+    }
+
+    public boolean isIncludeViewDataUrl()
+    {
+        return _includeViewDataUrl;
+    }
+
+    /**
+     * Pass false to omit view data URLs from the results. Default is true.
+     * @param includeViewDataUrl Set to 'false' to omit view data URLs.
+     */
+    public void setIncludeViewDataUrl(boolean includeViewDataUrl)
+    {
+        _includeViewDataUrl = includeViewDataUrl;
+    }
+
     @Override
     public Map<String, Object> getParameters()
     {
@@ -88,11 +119,15 @@ public class GetQueriesCommand extends Command<GetQueriesResponse>
         Map<String, Object> params = new HashMap<>();
         params.put("schemaName", getSchemaName());
 
-        if(!isIncludeColumns())
+        if (!isIncludeColumns())
             params.put("includeColumns", isIncludeColumns());
-        if(!isIncludeUserQueries())
+        if (!isIncludeTitle())
+            params.put("includeTitle", isIncludeTitle());
+        if (!isIncludeUserQueries())
             params.put("includeUserQueries", isIncludeUserQueries());
-        
+        if (!isIncludeViewDataUrl())
+            params.put("includeViewDataUrl", isIncludeViewDataUrl());
+
         return params;
     }
 

--- a/src/org/labkey/remoteapi/query/SelectRowsCommand.java
+++ b/src/org/labkey/remoteapi/query/SelectRowsCommand.java
@@ -18,7 +18,6 @@ package org.labkey.remoteapi.query;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -187,12 +186,15 @@ public class SelectRowsCommand extends BaseQueryCommand<SelectRowsResponse> impl
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String, Object> params = new HashMap<>();
+        Map<String, Object> params = super.getParameters();
+
         params.put("schemaName", getSchemaName());
         params.put("query.queryName", getQueryName());
-        if(null != getViewName())
+
+        if (null != getViewName())
             params.put("query.viewName", getViewName());
-        if(null != getColumns() && getColumns().size() > 0)
+
+        if (null != getColumns() && getColumns().size() > 0)
         {
             StringBuilder collist = new StringBuilder();
             String sep = "";
@@ -204,30 +206,7 @@ public class SelectRowsCommand extends BaseQueryCommand<SelectRowsResponse> impl
             }
             params.put("query.columns", collist);
         }
-        if(getMaxRows() >= 0)
-            params.put("query.maxRows", getMaxRows());
-        else
-            params.put("query.showRows", "all");
-        if(getOffset() > 0)
-            params.put("query.offset", getOffset());
-        if(null != getSorts() && getSorts().size() > 0)
-            params.put("query.sort", Sort.getSortQueryStringParam(getSorts()));
-
-        if(null != getFilters())
-        {
-            for(Filter filter : getFilters())
-                params.put("query." + filter.getQueryStringParamName(), filter.getQueryStringParamValue());
-        }
-
-        if (getContainerFilter() != null)
-            params.put("containerFilter", getContainerFilter().name());
-
-        for (Map.Entry<String, String> entry : getQueryParameters().entrySet())
-        {
-            params.put("query.param." + entry.getKey(), entry.getValue());
-        }
 
         return params;
     }
-
 }

--- a/src/org/labkey/remoteapi/test/Test.java
+++ b/src/org/labkey/remoteapi/test/Test.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.remoteapi.test;
 
-import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.assay.AssayListCommand;
@@ -59,7 +58,7 @@ public class Test
 
         try
         {
-            // Import /remoteapi/sas/People.xls as list "People" into project "Api Test"
+            // Import /remoteapi/labkey-api-java/People.xls as list "People" into project "Api Test"
             selectTest(cn, "Api Test");
             crudTest(cn, "Api Test");
             execSqlTest(cn, "Api Test");
@@ -83,7 +82,7 @@ public class Test
         }
     }
 
-    // Assumes that /remoteapi/sas/People.xls has been imported as a list into folder
+    // Assumes that /remoteapi/labkey-api-java/People.xls has been imported as a list into folder
     public static void selectTest(Connection cn, String folder) throws Exception
     {
         SelectRowsCommand cmd = new SelectRowsCommand("lists", "People");
@@ -103,7 +102,7 @@ public class Test
         }
     }
 
-    // Assumes that /remoteapi/sas/People.xls has been imported as a list into folder
+    // Assumes that /remoteapi/labkey-api-java/People.xls has been imported as a list into folder
     public static void crudTest(Connection cn, String folder) throws Exception
     {
         int rowCount = 0;
@@ -148,16 +147,16 @@ public class Test
         assert srresp.getRowCount().intValue() == rowCount;
     }
 
-    // Assumes that /remoteapi/sas/People.xls has been imported as a list into folder
+    // Assumes that /remoteapi/labkey-api-java/People.xls has been imported as a list into folder
     public static void truncateTableSuccessTest(Connection cn, String folder) throws Exception
     {
         TruncateTableCommand trunc = new TruncateTableCommand("lists", "People");
         TruncateTableResponse resp = trunc.execute(cn, folder);
 
-        assert resp.getDeletedRowCount().intValue() == 9;
+        assert resp.getDeletedRowCount() == 9;
     }
 
-    // Assumes that /remoteapi/sas/People.xls has been imported as a list into folder
+    // Assumes that /remoteapi/labkey-api-java/People.xls has been imported as a list into folder
     public static void execSqlTest(Connection cn, String folder) throws Exception
     {
         ExecuteSqlCommand cmd = new ExecuteSqlCommand("lists");
@@ -166,7 +165,7 @@ public class Test
         System.out.println(resp.getRows());
     }
 
-    // Assumes that /remoteapi/sas/People.xls has been imported as a list into folder
+    // Assumes that /remoteapi/labkey-api-java/People.xls has been imported as a list into folder
     private static void schemasTest(Connection cn, String folder) throws Exception
     {
         GetSchemasCommand cmd = new GetSchemasCommand();
@@ -188,7 +187,7 @@ public class Test
         }
     }
 
-    // Assumes that /remoteapi/sas/People.xls has been imported as a list into folder
+    // Assumes that /remoteapi/labkey-api-java/People.xls has been imported as a list into folder
     private static void extendedFormatTest(Connection cn, String folder) throws Exception
     {
         SelectRowsCommand cmd = new SelectRowsCommand("lists", "People");
@@ -199,7 +198,7 @@ public class Test
         {
             for (Map.Entry<String, Object> entry : row.entrySet())
             {
-                Object value = ((JSONObject)entry.getValue()).get("value");
+                Object value = ((Map<String, Object>)entry.getValue()).get("value");
                 System.out.println(entry.getKey() + " = " + value + " (type: " + (null == value ? "null" : value.getClass().getName()) + ")");
             }
         }
@@ -306,7 +305,8 @@ public class Test
     public static void truncateAssayFailsTest(Connection cn, String folder) throws Exception
     {
         TruncateTableCommand trunc = new TruncateTableCommand("assay.NAb.TestAssayNab", "WellData");
-        try{
+        try
+        {
             TruncateTableResponse resp = trunc.execute(cn, folder);
             throw new RuntimeException("Truncate table command should not succeed for tables other than lists," +
                     "datasets, sample sets, data classes, and issues");


### PR DESCRIPTION
#### Rationale
POST is better. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47030

#### Changes
* Switch `SelectRowsCommand` and `NAbRunsCommand` to always use POST
* Add support for  `includeTotalCount`, `includeMetadata`, and `ignoreFilter` flags to `BaseQueryCommand` and reconcile duplicate parameter handling code vs. SelectRowsCommand
* Add support for `includeTitle` and `includeViewDataUrl` flags to `GetQueriesCommand`
* Tweak `Test.java` comments and assumptions