### PR TITLE
Simple fix for SelectRowsCommand parameter map reuse regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## version 4.4.0-SNAPSHOT
 *Released*: TBD
 
-## version 4.3.1-selectrows_fix-SNAPSHOT
-*Released*: TBD
-* Fix regression introduced in 4.3.0: `SelectRowsCommand` should create a fresh parameter map for every invocation of `execute()`
+## version 4.3.1
+*Released*: 15 January 2023
+* Fix regression introduced in 4.3.0: `SelectRowsCommand` should create a fresh parameter map for every invocation of `getParameters()`
 
 ## version 4.3.0
 *Released*: 11 January 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## version 4.4.0-SNAPSHOT
 *Released*: TBD
 
+## version 4.3.1-selectrows_fix-SNAPSHOT
+*Released*: TBD
+* Fix regression introduced in 4.3.0: `SelectRowsCommand` should create a fresh parameter map for every invocation of `execute()`
+
 ## version 4.3.0
 *Released*: 11 January 2023
 * [Issue 47030](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47030): Switch `SelectRowsCommand` and `NAbRunsCommand` to always use POST

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.3.1-selectrows_fix-SNAPSHOT"
+version "4.4.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "4.4.0-SNAPSHOT"
+version "4.3.1-selectrows_fix-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/src/org/labkey/remoteapi/query/BaseQueryCommand.java
+++ b/src/org/labkey/remoteapi/query/BaseQueryCommand.java
@@ -280,7 +280,7 @@ public abstract class BaseQueryCommand<ResponseType extends CommandResponse> ext
     @Override
     public Map<String, Object> getParameters()
     {
-        Map<String, Object> params = super.getParameters();
+        Map<String, Object> params = new HashMap<>();
 
         if (getOffset() > 0)
             params.put("query.offset", getOffset());


### PR DESCRIPTION
#### Rationale
4.3.0 inadvertently caused `SelectRowsCommand` to reuse parameter maps across invocations of `execute()`, which could cause unexpected behavior. This PR restores the pre-4.3.0 behavior.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/46
