### PR TITLE
RowsResponse: stash _requiredVersion before data fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## version 5.1.0-SNAPSHOT
 *Released*: TBD
 
-## version 5.0.1-fix_fixup-SNAPSHOT
-*Released*: ?? January 2023
+## version 5.0.1
+*Released*: 30 January 2023
 * Fix regression introduced in 5.0.0: `RowsResponse.fixupParsedData()` was called before `_requiredVersion` was set. This caused
   the fixup method to skip `BigDecimal` to `Double` conversions in the returned data maps.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## version 5.1.0-SNAPSHOT
 *Released*: TBD
 
+## version 5.0.1-fix_fixup-SNAPSHOT
+*Released*: ?? January 2023
+* Fix regression introduced in 5.0.0: `RowsResponse.fixupParsedData()` was called before `_requiredVersion` was set. This caused
+  the fixup method to skip `BigDecimal` to `Double` conversions in the returned data maps.
+
 ## version 5.0.0
 *Released*: 24 January 2023
 * Refactor the `Command` class hierarchy:
@@ -23,7 +28,7 @@
 * Introduce `HasRequiredVersion` interface and use it when instantiating `CommandResponse` subclasses that need required version
 * Remove all `Command` copy constructors. Same rationale as the earlier removal of `copy` methods.
 * Switch `SelectRowsCommand` and `NAbRunsCommand` to post their parameters as JSON
-* Fix NAbReplicate to handle `"NaN"` values
+* Fix `NAbReplicate` to handle `"NaN"` values
 * Remove `CommandException` from `getHttpRequest()` throws list
 * Adjust the `Demo.java` and `Test.java` tests to match current sample data and `Command` hierarchy changes
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "5.0.1-fix_fixup-SNAPSHOT"
+version "5.0.1"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "5.1.0-SNAPSHOT"
+version "5.0.1-fix_fixup-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "5.0.1"
+version "5.1.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 sourceCompatibility=17
 targetCompatibility=17
 
-gradlePluginsVersion=1.39.0
+gradlePluginsVersion=1.39.1
 
 commonsCodecVersion=1.15
 commonsLoggingVersion=1.2
@@ -15,7 +15,7 @@ commonsLoggingVersion=1.2
 hamcrestVersion=1.3
 
 httpclient5Version=5.2.1
-httpcore5Version=5.2
+httpcore5Version=5.2.1
 
 jsonObjectVersion=20220924
 

--- a/src/org/labkey/remoteapi/query/RowsResponse.java
+++ b/src/org/labkey/remoteapi/query/RowsResponse.java
@@ -48,7 +48,7 @@ abstract class RowsResponse extends CommandResponse
     {
         super(text, statusCode, contentType, json);
         _requiredVersion = hasRequiredVersion.getRequiredVersion();
-        fixupParsedData();
+        fixupParsedData(_requiredVersion);
         caseInsensitizeRowMaps();
     }
 
@@ -57,6 +57,7 @@ abstract class RowsResponse extends CommandResponse
      * depending on the required version
      * @return the requested API version number
      */
+    @Deprecated // Just needed for fixup -- exposing this outside the class seems unnecessary. TODO: Remove this in v6.0.0
     public double getRequiredVersion()
     {
         return _requiredVersion;
@@ -83,7 +84,7 @@ abstract class RowsResponse extends CommandResponse
     /**
      * Fixes up the parsed data. Currently, this converts string-based date literals into real Java Date objects.
      */
-    private void fixupParsedData()
+    private void fixupParsedData(double requiredVersion)
     {
         if (null == getParsedData())
             return;
@@ -124,7 +125,7 @@ abstract class RowsResponse extends CommandResponse
         // date classes. If this format ever changes, we'll need to change the format string used here.
         // CONSIDER: use a library like ConvertUtils to avoid this dependency?
         DateParser dateFormat = new DateParser();
-        boolean expandedFormat = getRequiredVersion() == 9.1;
+        boolean expandedFormat = requiredVersion == 9.1;
 
         for (Map<String, Object> row : rows)
         {

--- a/src/org/labkey/remoteapi/query/RowsResponse.java
+++ b/src/org/labkey/remoteapi/query/RowsResponse.java
@@ -47,9 +47,9 @@ abstract class RowsResponse extends CommandResponse
     RowsResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
         super(text, statusCode, contentType, json);
+        _requiredVersion = hasRequiredVersion.getRequiredVersion();
         fixupParsedData();
         caseInsensitizeRowMaps();
-        _requiredVersion = hasRequiredVersion.getRequiredVersion();
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Unintentional change in v5.0.0 meant that `RowsResponse.fixupParsedData()` was called before `_requiredVersion` was set. This caused the fixup method to skip `BigDecimal` to `Double` conversions (and perhaps other problems).

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/48