### PR TITLE
Use typed getters and pattern vars to avoid casting

### DIFF
--- a/src/org/labkey/remoteapi/assay/GetAssayRunResponse.java
+++ b/src/org/labkey/remoteapi/assay/GetAssayRunResponse.java
@@ -29,7 +29,7 @@ public class GetAssayRunResponse extends CommandResponse
     public GetAssayRunResponse(String text, int statusCode, String contentType, JSONObject json)
     {
         super(text, statusCode, contentType, json);
-        JSONObject runJson = (JSONObject) json.get("run");
+        JSONObject runJson = json.getJSONObject("run");
         _run = new Run(runJson);
     }
 }

--- a/src/org/labkey/remoteapi/assay/LoadAssayBatchResponse.java
+++ b/src/org/labkey/remoteapi/assay/LoadAssayBatchResponse.java
@@ -19,7 +19,7 @@ public class LoadAssayBatchResponse extends CommandResponse
     public LoadAssayBatchResponse(String text, int statusCode, String contentType, JSONObject json)
     {
         super(text, statusCode, contentType, json);
-        _batch = new Batch((JSONObject) json.get("batch"));
+        _batch = new Batch(json.getJSONObject("batch"));
     }
 
     public Batch getBatch()

--- a/src/org/labkey/remoteapi/assay/ProtocolResponse.java
+++ b/src/org/labkey/remoteapi/assay/ProtocolResponse.java
@@ -10,7 +10,7 @@ public class ProtocolResponse extends CommandResponse
     public ProtocolResponse(String text, int statusCode, String contentType, JSONObject json)
     {
         super(text, statusCode, contentType, json);
-        _protocol = new Protocol((JSONObject) json.get("data"));
+        _protocol = new Protocol(json.getJSONObject("data"));
     }
 
     public Protocol getProtocol()

--- a/src/org/labkey/remoteapi/assay/SaveAssayBatchResponse.java
+++ b/src/org/labkey/remoteapi/assay/SaveAssayBatchResponse.java
@@ -26,7 +26,7 @@ public class SaveAssayBatchResponse extends CommandResponse
     public SaveAssayBatchResponse(String text, int statusCode, String contentType, JSONObject json)
     {
         super(text, statusCode, contentType, json);
-        _batch = new Batch((JSONObject)json.get("batch"));
+        _batch = new Batch(json.getJSONObject("batch"));
         _assayId = ((Number)json.get("assayId")).intValue();
     }
 

--- a/src/org/labkey/remoteapi/domain/ListDomainsResponse.java
+++ b/src/org/labkey/remoteapi/domain/ListDomainsResponse.java
@@ -24,7 +24,7 @@ public class ListDomainsResponse extends CommandResponse
     {
         super(text, statusCode, contentType, json);
         JSONArray domains = json.getJSONArray("data");
-        for(Object domainJSON: domains)
+        for (Object domainJSON: domains)
         {
             _domains.add(new Domain((JSONObject) domainJSON));
         }

--- a/src/org/labkey/remoteapi/query/SaveRowsCommand.java
+++ b/src/org/labkey/remoteapi/query/SaveRowsCommand.java
@@ -209,8 +209,10 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
             for(Map<String, Object> row : getRows())
             {
                 JSONObject jsonRow;
-                if(row instanceof JSONObject) //optimization
-                    jsonRow = (JSONObject)row;
+                if (row instanceof JSONObject jo) //optimization
+                {
+                    jsonRow = jo;
+                }
                 else
                 {
                     jsonRow = new JSONObject();


### PR DESCRIPTION
#### Rationale
Just a bit of cleanup
