### PR TITLE
Configure repository content for faster searching for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,12 @@ project.publishing {
                     basic(BasicAuthentication)
                     // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
                 }
+                content {
+                    includeGroup "org.labkey"
+                    includeGroup "org.labkey.api"
+                    includeGroup "org.labkey.module"
+                    includeGroup "org.maccosslab"
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,6 @@ project.publishing {
                     includeGroup "org.labkey"
                     includeGroup "org.labkey.api"
                     includeGroup "org.labkey.module"
-                    includeGroup "org.maccosslab"
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,35 @@ import org.labkey.gradle.util.PomFileHelper
 
 buildscript {
     repositories {
-        mavenCentral()
+        mavenCentral {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
+                mavenContent {
+                    snapshotsOnly()
+                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
+
         }
     }
     dependencies {
@@ -42,6 +62,9 @@ repositories {
                 basic(BasicAuthentication)
                 // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
             }
+        }
+        mavenContent {
+            releasesOnly()
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 sourceCompatibility=17
 targetCompatibility=17
 
-gradlePluginsVersion=1.40.1
+gradlePluginsVersion=1.41.0
 
 commonsCodecVersion=1.15
 commonsLoggingVersion=1.2


### PR DESCRIPTION
#### Rationale
By default, every repository that is declared is searched for dependencies, which can be wasteful when we know that some repositories will never contain certain dependencies.  Gradle has introduced ways to [configure repositories](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering) to filter the content that is served from them, reducing search time and traffic to the repo server when looking for a dependency.  Might as well take advantage of that. 

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/177
* https://github.com/LabKey/server/pull/497

#### Changes
* Designate repos as either snapshot-only or release-only
* Filter to known groups for tool repository and snapshot repository
