### PR TITLE
Update to Gradle 8.2.1 and adjust away from deprecated syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## version 5.3.0-SNAPSHOT
 *Released*: TBD
+* Update to Gradle 8.2.1 and adjust away from deprecated syntax
 
 ## version 5.2.0
 *Released*: 3 May 2023

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,9 @@ jar {
                 }
             }
 
-    libsDirName = "jar"
+}
+base {
+    libsDirectory = layout.buildDirectory.dir('jar')
 }
 
 project.tasks.withType(JavaCompile).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ hamcrestVersion=1.3
 httpclient5Version=5.2.1
 httpcore5Version=5.2.1
 
-jsonObjectVersion=20230227
+jsonObjectVersion=20230618
 
 junitVersion=4.13.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Rationale
With Gradle 8.2.1, we now get a warning about deprecated syntax for `libsDirName`. The deprecation is not scheduled for removal until Gradle 9.X, but might as well get rid of it now.

N.B., I'm not planning to publish a new version after this change

#### Changes
* Update Gradle version
* Update syntax for declaring `libsDirectory`
