### PR TITLE
Obfuscate SQL params passed by ExecuteSqlCommand and SqlExecuteCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## version 5.4.0-SNAPSHOT
 *Released*: TBD
+* Obfuscate SQL parameters passed by `ExecuteSqlCommand` and `SqlExecuteCommand` to avoid rejection by WAFs (earliest compatible LabKey Server version: 23.9.0)
+* Update HttpCore version
 
 ## version 5.3.0
 *Released*: 7 September 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## version 5.4.0-SNAPSHOT
 *Released*: TBD
-* Obfuscate SQL parameters passed by `ExecuteSqlCommand` and `SqlExecuteCommand` to avoid rejection by WAFs (earliest compatible LabKey Server version: 23.9.0)
+* Obfuscate SQL parameters passed by `ExecuteSqlCommand` and `SqlExecuteCommand` to avoid rejection by web application firewalls
+  * Earliest compatible LabKey Server version: 23.9.0
+  * These commands are no longer compatible with earlier versions of LabKey Server (23.8.x and before) by default, however,
+    if targeting an older server, calling `ExecuteSqlCommand.setWafEncoding(false)` will restore the previous behavior.
 * Update HttpCore version
 
 ## version 5.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ commonsLoggingVersion=1.2
 hamcrestVersion=1.3
 
 httpclient5Version=5.2.1
-httpcore5Version=5.2.2
+httpcore5Version=5.2.3
 
 jsonObjectVersion=20230618
 

--- a/src/org/labkey/remoteapi/internal/EncodeUtils.java
+++ b/src/org/labkey/remoteapi/internal/EncodeUtils.java
@@ -1,0 +1,41 @@
+package org.labkey.remoteapi.internal;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class EncodeUtils
+{
+    // Text that is first urlencoded to flatten UNICODE to ASCII then base64 encoded to avoid WAF rejection
+    public static final String WAF_PREFIX = "/*{{base64/x-www-form-urlencoded/wafText}}*/";
+
+    /**
+     * Obfuscates content that's often intercepted by web application firewalls that are scanning for likely SQL or
+     * script injection. We have a handful of endpoints that intentionally accept SQL or script, so we encode the text
+     * to avoid tripping alarms. It's a simple BASE64 encoding that obscures the content, and lets the WAF scan for and
+     * reject malicious content on all other parameters. See issue 48509 and PageFlowUtil.wafEncode()/wafDecode().
+     */
+    public static String wafEncode(String plain)
+    {
+        if (null == plain || plain.isBlank())
+        {
+            return null;
+        }
+        var step1 = encodeURIComponent(plain);
+        var step2 = step1.getBytes(StandardCharsets.US_ASCII);
+        return WAF_PREFIX + Base64.getEncoder().encodeToString(step2);
+    }
+
+    /**
+     * URL Encode string.
+     * NOTE! this should be used on parts of a url, not an entire url
+     * Like JavaScript encodeURIComponent()
+     */
+    public static String encodeURIComponent(String s)
+    {
+        if (null == s)
+            return "";
+        String enc = URLEncoder.encode(s, StandardCharsets.UTF_8);
+        return enc.replace("+", "%20");
+    }
+}

--- a/src/org/labkey/remoteapi/query/ExecuteSqlCommand.java
+++ b/src/org/labkey/remoteapi/query/ExecuteSqlCommand.java
@@ -48,6 +48,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     private boolean _saveInSession = false;
     private boolean _includeDetailsColumn = false;
     private Map<String, String> _queryParameters = new HashMap<>();
+    private boolean _wafEncoding = true;
 
     /**
      * Constructs an ExecuteSqlCommand, initialized with a schema name.
@@ -306,6 +307,20 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
         _containerFilter = containerFilter;
     }
 
+    public boolean getWafEncoding()
+    {
+        return _wafEncoding;
+    }
+
+    /**
+     * By default, this command encodes the SQL parameter to allow it to pass through web application firewalls. This
+     * is compatible with LabKey Server v23.9.0 and above. If targeting an earlier server, pass false to this method.
+     */
+    public void setWafEncoding(boolean wafEncoding)
+    {
+        _wafEncoding = wafEncoding;
+    }
+
     @Override
     protected SelectRowsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
@@ -319,7 +334,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     {
         JSONObject json = new JSONObject();
         json.put("schemaName", getSchemaName());
-        json.put("sql", EncodeUtils.wafEncode(getSql()));
+        json.put("sql", getWafEncoding() ? EncodeUtils.wafEncode(getSql()) : getSql());
         if (getMaxRows() >= 0)
             json.put("maxRows", getMaxRows());
         if (getOffset() > 0)

--- a/src/org/labkey/remoteapi/query/ExecuteSqlCommand.java
+++ b/src/org/labkey/remoteapi/query/ExecuteSqlCommand.java
@@ -17,6 +17,7 @@ package org.labkey.remoteapi.query;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.internal.EncodeUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -198,7 +199,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
      The value of this property should be a comma-delimited list of column names you want to sort by.
      Use a - prefix to sort a column in descending order
      (e.g., 'LastName,-Age' to sort first by LastName, then by Age descending).
-     @return the set of sorts to apply
+     @return the list of sorts to apply
      */
     public List<Sort> getSorts()
     {
@@ -219,7 +220,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     }
 
     /**
-     * Whether or not the definition of this query should be stored for reuse during the current session.
+     * Whether the definition of this query should be stored for reuse during the current session.
      * If true, all information required to recreate the query will be stored on the server and a unique query name
      * will be passed to the success callback. This temporary query name can be used by all other API methods,
      * including Query Web Part creation, for as long as the current user's session remains active.
@@ -231,7 +232,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     }
 
     /**
-     * Whether or not the definition of this query should be stored for reuse during the current session.
+     * Whether the definition of this query should be stored for reuse during the current session.
      * If true, all information required to recreate the query will be stored on the server and a unique query name
      * will be passed to the success callback. This temporary query name can be used by all other API methods,
      * including Query Web Part creation, for as long as the current user's session remains active.
@@ -267,7 +268,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     /**
      Map of name (string)/value pairs for the values of parameters if the SQL references underlying queries
      that are parameterized.
-     @return the set of query parameters for the SQL references
+     @return map of query parameters for the SQL references
      */
     public Map<String, String> getQueryParameters()
     {
@@ -318,7 +319,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     {
         JSONObject json = new JSONObject();
         json.put("schemaName", getSchemaName());
-        json.put("sql", getSql());
+        json.put("sql", EncodeUtils.wafEncode(getSql()));
         if (getMaxRows() >= 0)
             json.put("maxRows", getMaxRows());
         if (getOffset() > 0)
@@ -337,7 +338,7 @@ public class ExecuteSqlCommand extends PostCommand<SelectRowsResponse> implement
     {
         Map<String, Object> params = super.createParameterMap();
 
-        if (null != getSorts() && getSorts().size() > 0)
+        if (null != getSorts() && !getSorts().isEmpty())
             params.put("query.sort", Sort.getSortQueryStringParam(getSorts()));
 
         for (Map.Entry<String, String> entry : getQueryParameters().entrySet())

--- a/src/org/labkey/remoteapi/query/Filter.java
+++ b/src/org/labkey/remoteapi/query/Filter.java
@@ -237,8 +237,8 @@ public class Filter
     public String getQueryStringParamName()
     {
         return (null == getColumnName() || null == getOperator())
-                ? ""
-                : getColumnName() + "~" + getOperator().getUrlKey();
+            ? ""
+            : getColumnName() + "~" + getOperator().getUrlKey();
     }
 
     /**

--- a/src/org/labkey/remoteapi/query/SqlExecuteCommand.java
+++ b/src/org/labkey/remoteapi/query/SqlExecuteCommand.java
@@ -18,6 +18,7 @@ package org.labkey.remoteapi.query;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.internal.EncodeUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,10 +44,10 @@ public class SqlExecuteCommand extends PostCommand<CommandResponse>
 
     private String _schemaName;
     private String _sql;
-    private Map<String, Object> _queryParameters = new HashMap<>();
-    private String _sep = us_char + "\t";
-    private String _eol = us_char + "\n";
-    private boolean _compact = true;
+    private final Map<String, Object> _queryParameters = new HashMap<>();
+    private final String _sep = us_char + "\t";
+    private final String _eol = us_char + "\n";
+    private final boolean _compact = true;
 
     /**
      * Constructs an ExecuteSqlCommand, initialized with a schema name.
@@ -107,7 +108,7 @@ public class SqlExecuteCommand extends PostCommand<CommandResponse>
     /**
      Map of name (string)/value pairs for the values of parameters if the SQL references underlying queries
      that are parameterized.
-     @return the set of query parameters for the SQL references
+     @return map of query parameters for the SQL references
      */
     public Map<String, Object> getQueryParameters()
     {
@@ -129,6 +130,7 @@ public class SqlExecuteCommand extends PostCommand<CommandResponse>
     {
         return _eol;
     }
+
     public String getFieldSeparator()
     {
         return _sep;
@@ -139,7 +141,7 @@ public class SqlExecuteCommand extends PostCommand<CommandResponse>
     {
         JSONObject json = new JSONObject();
         json.put("schema", getSchemaName());
-        json.put("sql", getSql());
+        json.put("sql", EncodeUtils.wafEncode(getSql()));
         json.put("parameters", getQueryParameters());
         json.put("eol", _eol);
         json.put("sep", _sep);


### PR DESCRIPTION
#### Rationale
Encoding legitimate LabKey SQL parameters allows them to pass through web application firewalls

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48560

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4699
