### PR TITLE
Fix so all command responses correctly decode as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # The LabKey Remote API Library for Java - Change Log
 
 ## version 6.1.0-SNAPSHOT
+*Released*: TBD
+* [Issue 49238](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49238): Fix so all command responses correctly decode as UTF-8.
 
 ## version 6.0.0
 *Released*: 1 December 2023
 * Encode SQL parameters passed by `ExecuteSqlCommand` and `SqlExecuteCommand` to avoid rejection by web application firewalls
   * Earliest compatible LabKey Server version: 23.9.0
-  * These commands are no longer compatible with earlier versions of LabKey Server (23.8.x and before) by default, however,
+  * These commands are no longer compatible with earlier versions of LabKey Server (23.8.x and before) by default. However,
     if targeting an older server, calling `ExecuteSqlCommand.setWafEncoding(false)` will restore the previous behavior.
 * Update HttpCore, JSON-java, Gradle Plugins, and Gradle versions
 
@@ -51,7 +53,7 @@
   * `setJsonObject()` is now available only on `SimplePostCommand`. Custom `PostCommand` subclasses that need to post JSON are
     expected to override `getJsonObject()`.
 * Stop passing command subclasses when constructing every `CommandResponse`. The two response classes that need this now implement
-  it without burdening all other commands. 
+  it without burdening all other commands.
 * Introduce `HasRequiredVersion` interface and use it when instantiating `CommandResponse` subclasses that need required version
 * Remove all `Command` copy constructors. Same rationale as the earlier removal of `copy` methods.
 * Switch `SelectRowsCommand` and `NAbRunsCommand` to post their parameters as JSON
@@ -65,8 +67,7 @@
 
 ## version 4.3.0
 *Released*: 11 January 2023
-* [Issue 47030](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47030): Switch `SelectRowsCommand`
-  and `NAbRunsCommand` to always use POST
+* [Issue 47030](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47030): Switch `SelectRowsCommand` and `NAbRunsCommand` to always use POST
 * Add support for `includeTotalCount`, `includeMetadata`, and `ignoreFilter` flags to `BaseQueryCommand` and reconcile 
   duplicate parameter handling code vs. SelectRowsCommand
 * Add support for `includeTitle` and `includeViewDataUrl` flags to `GetQueriesCommand`

--- a/src/org/labkey/remoteapi/Command.java
+++ b/src/org/labkey/remoteapi/Command.java
@@ -276,7 +276,7 @@ public abstract class Command<ResponseType extends CommandResponse, RequestType 
             if (_responseText != null)
                 return _responseText;
 
-            try (Scanner s = new Scanner(_httpResponse.getEntity().getContent()).useDelimiter("\\A"))
+            try (Scanner s = new Scanner(_httpResponse.getEntity().getContent(), StandardCharsets.UTF_8).useDelimiter("\\A"))
             {
                 // Simple InputStream -> String conversion
                 return s.hasNext() ? s.next() : "";
@@ -362,7 +362,7 @@ public abstract class Command<ResponseType extends CommandResponse, RequestType 
         if (null != contentType && contentType.contains(CONTENT_TYPE_JSON))
         {
             // Parse JSON
-            if (responseText != null && responseText.length() > 0)
+            if (responseText != null && !responseText.isEmpty())
             {
                 json = new JSONObject(responseText);
                 if (json.has("exception"))
@@ -447,7 +447,7 @@ public abstract class Command<ResponseType extends CommandResponse, RequestType 
         StringBuilder path = new StringBuilder(uri.getPath() == null || "".equals(uri.getPath()) ? "/" : uri.getPath());
 
         //add the folderPath (if any)
-        if (null != folderPath && folderPath.length() > 0)
+        if (null != folderPath && !folderPath.isEmpty())
         {
             String folderPathNormalized = folderPath.replace('\\', '/');
             if (folderPathNormalized.charAt(0) == '/') // strip leading slash


### PR DESCRIPTION
#### Rationale
`SaveRowsResponse`, and likely other responses, weren't handling special characters correctly. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49238