### PR TITLE
Add MoveRowsCommand to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## version 6.1.0-SNAPSHOT
 *Released*: TBD
 * [Issue 49238](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49238): Fix so all command responses correctly decode as UTF-8.
+* Add MoveRowsCommand to query
+  * Earliest compatible LabKey Server version: 24.1.0
 
 ## version 6.0.0
 *Released*: 1 December 2023

--- a/src/org/labkey/remoteapi/query/MoveRowsCommand.java
+++ b/src/org/labkey/remoteapi/query/MoveRowsCommand.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2009 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.remoteapi.query;
+
+import org.json.JSONObject;
+
+/**
+ * Command for moving rows from a compatible schema table. The user associated
+ * with the connection used when executing this command must have
+ * permission to update data for the source container and insert data
+ * for the target container.
+ */
+public class MoveRowsCommand extends SaveRowsCommand
+{
+    private final String _targetContainerPath;
+
+    /**
+     * Constructs a MoveRowsCommand for the given targetContainerPath, schemaName, and queryName.
+     * See the {@link SaveRowsCommand} for more details.
+     * @param targetContainerPath The targetContainerPath
+     * @param schemaName The schemaName
+     * @param queryName The queryName.
+     * @see SaveRowsCommand
+     */
+    public MoveRowsCommand(String targetContainerPath, String schemaName, String queryName)
+    {
+        super(schemaName, queryName, "moveRows");
+        _targetContainerPath = targetContainerPath;
+    }
+
+    @Override
+    public JSONObject getJsonObject()
+    {
+        final JSONObject jsonObject = super.getJsonObject();
+        jsonObject.put("targetContainerPath", _targetContainerPath);
+        return jsonObject;
+    }
+}

--- a/src/org/labkey/remoteapi/query/MoveRowsCommand.java
+++ b/src/org/labkey/remoteapi/query/MoveRowsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2009 LabKey Corporation
+ * Copyright (c) 2023 LabKey Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/org/labkey/remoteapi/query/SaveRowsCommand.java
+++ b/src/org/labkey/remoteapi/query/SaveRowsCommand.java
@@ -200,7 +200,9 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
     }
 
     /**
-     * Used to override the audit behavior for the schema/query
+     * Used to override the audit behavior for the schema/query.
+     * Note that any audit behavior type that is configured via an XML file for the given schema/query
+     * will take precedence over this value. See TableInfo.getAuditBehavior() for more details.
      * @param auditBehavior Valid values include "NONE", "SUMMARY", and "DETAILED"
      */
     public void setAuditBehavior(AuditBehavior auditBehavior)

--- a/src/org/labkey/remoteapi/query/SaveRowsCommand.java
+++ b/src/org/labkey/remoteapi/query/SaveRowsCommand.java
@@ -83,10 +83,19 @@ import java.util.Map;
  */
 public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
 {
+    public enum AuditBehavior
+    {
+        NONE,
+        SUMMARY,
+        DETAILED
+    }
+
     private String _schemaName;
     private String _queryName;
     private Map<String, Object> _extraContext;
     private List<Map<String, Object>> _rows = new ArrayList<>();
+    private AuditBehavior _auditBehavior;
+    private String _auditUserComment;
 
     /**
      * Constructs a new SaveRowsCommand for a given schema, query and action name.
@@ -185,6 +194,34 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
         _rows.add(row);
     }
 
+    public AuditBehavior getAuditBehavior()
+    {
+        return _auditBehavior;
+    }
+
+    /**
+     * Used to override the audit behavior for the schema/query
+     * @param auditBehavior Valid values include "NONE", "SUMMARY", and "DETAILED"
+     */
+    public void setAuditBehavior(AuditBehavior auditBehavior)
+    {
+        _auditBehavior = auditBehavior;
+    }
+
+    public String getAuditUserComment()
+    {
+        return _auditUserComment;
+    }
+
+    /**
+     * Used to provide a comment that will be attached to certain detailed audit log records
+     * @param auditUserComment The comment to attach to the detailed audit log records
+     */
+    public void setAuditUserComment(String auditUserComment)
+    {
+        _auditUserComment = auditUserComment;
+    }
+
     /**
      * Dynamically builds the JSON object to send based on the current
      * schema name, query name and rows list.
@@ -198,6 +235,10 @@ public abstract class SaveRowsCommand extends PostCommand<SaveRowsResponse>
         json.put("queryName", getQueryName());
         if (getExtraContext() != null)
             json.put("extraContext", getExtraContext());
+        if (getAuditBehavior() != null)
+            json.put("auditBehavior", getAuditBehavior());
+        if (getAuditUserComment() != null)
+            json.put("auditUserComment", getAuditUserComment());
 
         //unfortunately, JSON simple is so simple that it doesn't
         //encode maps into JSON objects on the fly,


### PR DESCRIPTION
#### Rationale
Related PR added a query-moveRows.api to the QueryController so that we could consolidate the various move entities actions to a single action. This PR adds MoveRowsCommand to the package.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/167
- https://github.com/LabKey/labkey-api-r/pull/100
- https://github.com/LabKey/labkey-api-python/pull/73

#### Changes
- Add MoveRowsCommand to query
- Add optional auditBehavior and auditUserComment to SaveRowsCommand
