### PR TITLE
Teach ApiKeyCredentialsProvider to respond to server auth challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   and `setIncludeInactive()` instead.
 * Update Commons Logging, Gradle, Gradle Plugins, HttpClient, and HttpCore versions
 * Remove Hamcrest references (unused)
+* Update `ApiKeyCredentialsProvider` to respond to server auth challenges with the `apikey` header and use the session
+  on subsequent requests.
 
 ## version 6.0.0
 *Released*: 1 December 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 * Remove deprecated method `RowsResponse.getRequiredVersion()`.
 * Deprecate `GetUsersCommand` methods `getIncludeDeactivated()` and `setIncludeDeactivated()`; use `getIncludeInactive()`
   and `setIncludeInactive()` instead.
-* Update Commons Logging, Gradle, Gradle Plugins, HttpClient, and HttpCore versions
 * Remove Hamcrest references (unused)
 * Update `ApiKeyCredentialsProvider` to respond to server auth challenges with the `apikey` header and use the session
   on subsequent requests.
+* Update Commons Logging, Gradle, Gradle Plugins, HttpClient, and HttpCore versions
 
 ## version 6.0.0
 *Released*: 1 December 2023

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 sourceCompatibility=17
 targetCompatibility=17
 
-gradlePluginsVersion=2.0.0
+gradlePluginsVersion=2.2.1
 
 commonsCodecVersion=1.16.0
 commonsLoggingVersion=1.3.0
 
-httpclient5Version=5.3
+httpclient5Version=5.3.1
 httpcore5Version=5.2.4
 
 jsonObjectVersion=20231013

--- a/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
+++ b/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
@@ -51,13 +51,16 @@ public class ApiKeyCredentialsProvider implements CredentialsProvider
     @Override
     public boolean shouldRetryRequest(CommandException exception, HttpUriRequest request)
     {
-        // Set the apikey header and retry the request in response to a Basic Auth challenge; subsequent requests should
-        // use the session. This mimics the behavior of BasicAuthCredentialsProvider.
-        boolean retry = exception instanceof AuthChallengeException;
+        // Determine if this is a Basic Auth challenge. If so, set the apikey header and retry the request. Subsequent
+        // requests should use the session. This mimics the behavior of BasicAuthCredentialsProvider.
 
-        if (retry)
+        String authHeaderValue = exception.getAuthHeaderValue();
+
+        boolean authChallenge = (null != authHeaderValue && authHeaderValue.startsWith("Basic realm") && "You must log in to view this content.".equals(exception.getMessage()));
+
+        if (authChallenge)
             request.setHeader("apikey", _apiKey);
 
-        return retry;
+        return authChallenge;
     }
 }

--- a/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
+++ b/src/org/labkey/remoteapi/ApiKeyCredentialsProvider.java
@@ -52,7 +52,7 @@ public class ApiKeyCredentialsProvider implements CredentialsProvider
     public boolean shouldRetryRequest(CommandException exception, HttpUriRequest request)
     {
         // Set the apikey header and retry the request in response to a Basic Auth challenge; subsequent requests should
-        // use the session. This mimics the behavior of the BasicAuthCredentialsProvider.
+        // use the session. This mimics the behavior of BasicAuthCredentialsProvider.
         boolean retry = exception instanceof AuthChallengeException;
 
         if (retry)

--- a/src/org/labkey/remoteapi/ApiVersionException.java
+++ b/src/org/labkey/remoteapi/ApiVersionException.java
@@ -19,8 +19,8 @@ import org.json.JSONObject;
 
 public class ApiVersionException extends CommandException
 {
-    ApiVersionException(String message, int statusCode, JSONObject jsonProperties, String responseText, String contentType)
+    ApiVersionException(String message, int statusCode, JSONObject jsonProperties, String responseText, String contentType, String authHeaderValue)
     {
-        super(message, statusCode, jsonProperties, responseText, contentType);
+        super(message, statusCode, jsonProperties, responseText, contentType, authHeaderValue);
     }
 }

--- a/src/org/labkey/remoteapi/AuthChallengeException.java
+++ b/src/org/labkey/remoteapi/AuthChallengeException.java
@@ -1,0 +1,9 @@
+package org.labkey.remoteapi;
+
+public class AuthChallengeException extends CommandException
+{
+    public AuthChallengeException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/org/labkey/remoteapi/AuthChallengeException.java
+++ b/src/org/labkey/remoteapi/AuthChallengeException.java
@@ -1,9 +1,0 @@
-package org.labkey.remoteapi;
-
-public class AuthChallengeException extends CommandException
-{
-    public AuthChallengeException(String message)
-    {
-        super(message);
-    }
-}

--- a/src/org/labkey/remoteapi/Command.java
+++ b/src/org/labkey/remoteapi/Command.java
@@ -182,7 +182,7 @@ public abstract class Command<ResponseType extends CommandResponse, RequestType 
     public ResponseType execute(Connection connection, String folderPath) throws IOException, CommandException
     {
         // Execute the command. Throws CommandException for error responses.
-        try (Response response = executeWithPossibleRetry(connection, folderPath))
+        try (Response response = _execute(connection, folderPath))
         {
             // For non-streaming Commands, read the entire response body into memory as JSON or a String.
             // The json and responseText will already be parsed when checking for an exception message on small 200 responses.
@@ -307,7 +307,7 @@ public abstract class Command<ResponseType extends CommandResponse, RequestType 
         }
     }
 
-    private Response executeWithPossibleRetry(Connection connection, String folderPath) throws CommandException, IOException
+    protected Response _execute(Connection connection, String folderPath) throws CommandException, IOException
     {
         assert null != getControllerName() : "You must set the controller name before executing the command!";
         assert null != getActionName() : "You must set the action name before executing the command!";

--- a/src/org/labkey/remoteapi/CommandException.java
+++ b/src/org/labkey/remoteapi/CommandException.java
@@ -38,6 +38,7 @@ import java.util.Map;
 public class CommandException extends Exception
 {
     private final String _contentType;
+    private final String _authHeaderValue;
     private final int _statusCode;
     private final JSONObject _jsonProperties;
     private final String _responseText;
@@ -49,7 +50,7 @@ public class CommandException extends Exception
      */
     public CommandException(String message)
     {
-        this(message, 0, null, null, null);
+        this(message, 0, null, null, null, null);
     }
 
     /**
@@ -60,14 +61,16 @@ public class CommandException extends Exception
      * @param jsonProperties The exception property JSONObject (may be null)
      * @param responseText The full response text (may be null)
      * @param contentType The response content type (may be null)
+     * @param authHeaderValue The value of the WWW-Authenticate header (may be null)
      */
-    public CommandException(String message, int statusCode, JSONObject jsonProperties, String responseText, String contentType)
+    public CommandException(String message, int statusCode, JSONObject jsonProperties, String responseText, String contentType, String authHeaderValue)
     {
         super(buildMessage(message, statusCode));
         _statusCode = statusCode;
         _jsonProperties = jsonProperties;
         _responseText = responseText;
         _contentType = contentType;
+        _authHeaderValue = authHeaderValue;
     }
 
     private static String buildMessage(String message, int statusCode)
@@ -112,6 +115,15 @@ public class CommandException extends Exception
     public String getResponseText()
     {
         return _responseText;
+    }
+
+    /**
+     * Returns the value of the WWW-Authenticate header
+     * @return The value or null
+     */
+    public String getAuthHeaderValue()
+    {
+        return _authHeaderValue;
     }
 
     /**

--- a/src/org/labkey/remoteapi/Connection.java
+++ b/src/org/labkey/remoteapi/Connection.java
@@ -398,7 +398,7 @@ public class Connection
 
         CloseableHttpClient client = getHttpClient();
 
-        // Set the timeout on the request if it is different the client's default
+        // Set the timeout on the request if it's different from the client's default
         if (request instanceof HttpUriRequestBase r && timeout != null && timeout != getTimeout())
         {
             RequestConfig base = r.getConfig();
@@ -488,6 +488,11 @@ public class Connection
     public void setUserAgent(String userAgent)
     {
         _userAgent = userAgent;
+    }
+
+    public CredentialsProvider getCredentialsProvider()
+    {
+        return _credentialsProvider;
     }
 
     /**

--- a/src/org/labkey/remoteapi/CredentialsProvider.java
+++ b/src/org/labkey/remoteapi/CredentialsProvider.java
@@ -29,8 +29,16 @@ public interface CredentialsProvider
     void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException;
 
     /**
-     * Initialize the connection before its first request. If connection-based, authenticate the user. In all cases,
-     * retrieve the CSRF token and session ID to use with subsequent requests on this connection.
+     * Initialize the connection before its first request. For example, make a request to retrieve CSRF token & session
+     * ID and/or ensure the user is logged in.
      */
     void initializeConnection(Connection connection) throws IOException, CommandException;
+
+    /**
+     * Should the Command attempt to retry the request?
+     */
+    default boolean shouldRetryRequest(CommandException exception, HttpUriRequest request)
+    {
+        return false;
+    }
 }

--- a/src/org/labkey/remoteapi/CredentialsProvider.java
+++ b/src/org/labkey/remoteapi/CredentialsProvider.java
@@ -29,7 +29,7 @@ public interface CredentialsProvider
     void configureRequest(URI baseURI, HttpUriRequest request, HttpClientContext httpClientContext) throws AuthenticationException;
 
     /**
-     * Initialize the connection before its first request. For example, make a request to retrieve CSRF token & session
+     * Initialize the connection before its first request. For example, make a request to retrieve CSRF token &amp; session
      * ID and/or ensure the user is logged in.
      */
     void initializeConnection(Connection connection) throws IOException, CommandException;


### PR DESCRIPTION
#### Rationale
Previously, `ApiKeyCredentialsProvider` blindly added an `apikey` header to every request. Now, it responds to a `WWW-Authenticate` challenge from the server with the `apikey` header and subsequently uses the session. This matches the behavior of `BasicAuthCredentialsProvider`. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49432