### PR TITLE
Add support for auditUserComment field for assay import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## version 6.2.0-SNAPSHOT
 *Released*: TBD
+* Add support for `auditUserComment` field for assay import
 
 ## version 6.1.0-SNAPSHOT
 *Released*: 26 February 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 6.2.0-SNAPSHOT
+## version TBD
 *Released*: TBD
 * Add support for `auditUserComment` field for assay import
 
-## version 6.1.0-SNAPSHOT
+## version 6.1.0
 *Released*: 26 February 2024
 * [Issue 49238](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49238): Fix so all command responses correctly decode as UTF-8.
 * Add MoveRowsCommand to query

--- a/src/org/labkey/remoteapi/assay/ImportRunCommand.java
+++ b/src/org/labkey/remoteapi/assay/ImportRunCommand.java
@@ -40,6 +40,7 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
     private String _comment;
     private Map<String, Object> _properties;
     private Map<String, Object> _batchProperties;
+    private String _auditUserComment;
 
     // Only one of the follow is allowed
     private List<Map<String, Object>> _dataRows;
@@ -116,6 +117,11 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
         _plateMetadata = plateMetadata;
     }
 
+    public void setAuditUserComment(String auditUserComment)
+    {
+        _auditUserComment = auditUserComment;
+    }
+
     @Override
     protected ImportRunResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
@@ -157,6 +163,8 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
                 json.put("runFilePath", _runFilePath);
             if (_plateMetadata != null)
                 json.put("plateMetadata", _plateMetadata);
+            if (_auditUserComment != null)
+                json.put("auditUserComment", _auditUserComment);
 
             builder.addTextBody("json", json.toString(), ContentType.APPLICATION_JSON);
         }
@@ -169,6 +177,8 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
                 builder.addTextBody("name", _name);
             if (_comment != null)
                 builder.addTextBody("comment", _comment);
+            if (_auditUserComment != null)
+                builder.addTextBody("auditUserComment", _auditUserComment);
             if (_properties != null)
             {
                 for (Map.Entry<String, Object> entry : _properties.entrySet())


### PR DESCRIPTION
#### Rationale
We recently added the ability to add comments to be recorded in the audit log when editing or reimporting assay runs. This PR adds the `auditUserComment` parameter to the `ImportRunCommand` interface as well.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5286

#### Changes
* Add `auditUserComment` to `ImportRunCommand`
