### PR TITLE
Prepare for next dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # The LabKey Remote API Library for Java - Change Log
 
+## version 6.3.0-SNAPSHOT
+*Released*: TBD
+
 ## version 6.2.0
 *Released*: 29 July 2024
 * Add support for `auditUserComment` field for assay import
 * Add support for `allowPlateMetadata`, `plateMetadata` fields for assay plate support
-* Deprecate `GetContainersResponse` permissions methods which are incompatible with LabKey Server v24.8 and 
+* Deprecate `GetContainersResponse` permissions methods which are incompatible with LabKey Server v24.8+ 
 * Update Commons Codec, Commons Logging, Gradle, Gradle Plugins, HttpCore, and JSONObject versions
 
 ## version 6.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ repositories {
 
 group "org.labkey.api"
 
-version "6.2.0"
+version "6.3.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"


### PR DESCRIPTION
#### Rationale
v6.2.0 has been published and we need to prepare develop for the next cycle.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/73