### PR TITLE
Use non-deprecated syntax as of Gradle 8.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url = "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
@@ -23,7 +23,7 @@ buildscript {
         {
             mavenLocal()
             maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
+                url = "${artifactory_contextUrl}/plugins-snapshot-local"
                 mavenContent {
                     snapshotsOnly()
                 }
@@ -50,7 +50,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url "${artifactory_contextUrl}/libs-release-no-proxy"
+        url = "${artifactory_contextUrl}/libs-release-no-proxy"
 
         if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
         {
@@ -69,9 +69,9 @@ repositories {
     }
 }
 
-group "org.labkey.api"
+group = "org.labkey.api"
 
-version "6.3.0-SNAPSHOT"
+version = "6.3.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"
@@ -138,7 +138,7 @@ project.tasks.register('javadocJar', Jar) {
     Jar jar ->
         jar.description = "Generate jar file of javadoc files"
         jar.from project.tasks.javadoc.destinationDir
-        jar.group GroupNames.DISTRIBUTION
+        jar.group = GroupNames.DISTRIBUTION
         jar.archiveClassifier.set(LabKey.JAVADOC_CLASSIFIER)
         jar.dependsOn project.tasks.javadoc
 }
@@ -147,7 +147,7 @@ project.tasks.register('sourcesJar', Jar) {
     Jar jar ->
         jar.description = "Generate jar file of source files"
         jar.from project.sourceSets.main.allJava
-        jar.group GroupNames.DISTRIBUTION
+        jar.group = GroupNames.DISTRIBUTION
         jar.archiveClassifier.set(LabKey.SOURCES_CLASSIFIER)
 }
 
@@ -200,10 +200,10 @@ project.publishing {
         if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
         {
             maven {
-                url sonatype_staging_url
+                url = sonatype_staging_url
                 credentials {
-                    username sonatype_username
-                    password sonatype_password
+                    username = sonatype_username
+                    password = sonatype_password
                 }
             }
         }
@@ -211,7 +211,7 @@ project.publishing {
         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
         {
             maven {
-                url project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
+                url = project.version.contains("SNAPSHOT") ? "${artifactory_contextUrl}/libs-snapshot-local" : "${artifactory_contextUrl}/libs-release-local"
                 credentials {
                     username = artifactory_user
                     password = artifactory_password

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
#### Rationale
Gradle [8.12](https://docs.gradle.org/8.12/release-notes.html) has started emitting warnings about "space assignments" being deprecated, so we now have good reason to get rid of this confusing syntax.

#### Changes
* Update some syntax to non-deprecated versions
