### PR TITLE
Issue 53059: Use new plugin for publishing using new Maven Central API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 6.3.0-SNAPSHOT
+## vresion 6.4.0-SNAPSHOT
 *Released*: TBD
+* 
+
+## version 6.3.0
+*Released*: 19 June 2025
 * Update Commons Codec, Commons Logging, Gradle, Gradle Plugins, HttpClient, HttpCore, and JSONObject versions
 * Remove defunct FileNotification API and uses
 * Update publishing method for new Maven Central API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 6.3.0-SNAPSHOT
+## version 6.3.0
 *Released*: TBD
 * Update Commons Codec, Commons Logging, Gradle, Gradle Plugins, HttpClient, HttpCore, and JSONObject versions
 * Remove defunct FileNotification API and uses
+* Update publishing method for new Maven Central API
 
 ## version 6.2.0
 *Released*: 29 July 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 6.3.0
+## version 6.3.0-SNAPSHOT
 *Released*: TBD
 * Update Commons Codec, Commons Logging, Gradle, Gradle Plugins, HttpClient, HttpCore, and JSONObject versions
 * Remove defunct FileNotification API and uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## vresion 6.4.0-SNAPSHOT
+## version 6.4.0-SNAPSHOT
 *Released*: TBD
 * 
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "6.3.0-SNAPSHOT"
+version = "6.4.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -232,15 +232,18 @@ if (project.hasProperty("signing.keyId") && project.hasProperty("signing.passwor
     }
 }
 
+if (project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
+{
 // Plugin that uses the New Maven Central Publishing (NMCP) API to publish Maven artifacts. https://github.com/GradleUp/nmcp
-nmcp {
-    centralPortal {
-        username = sonatype_username
-        password = sonatype_password
-        // publish manually from the portal
-        publishingType = "USER_MANAGED"
+    nmcp {
+        centralPortal {
+            username = sonatype_username
+            password = sonatype_password
+            // publish manually from the portal
+            publishingType = "USER_MANAGED"
 //        // or if you want to publish automatically
 //        publishingType = "AUTOMATIC"
+        }
     }
 }
 
@@ -248,6 +251,9 @@ project.tasks.register('publishRelease', DefaultTask) {
     DefaultTask task ->
         task.group = 'Publishing'
         task.description = 'Publish to Local repository and Maven Central'
-        task.dependsOn(tasks.publish, tasks.publishLibsPublicationToCentralPortal)
+        if (project.hasProperty("artifactory_user") && project.hasProperty("artifactory_password"))
+            task.dependsOn(tasks.publish)
+        if (project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
+            task.dependsOn(tasks.publishLibsPublicationToCentralPortal)
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'signing'
+    id("com.gradleup.nmcp").version("0.1.4") // https://github.com/GradleUp/nmcp
 }
 
 repositories {
@@ -196,17 +197,6 @@ project.publishing {
         }
     }
     repositories {
-        if (project.hasProperty("sonatype_staging_url") && project.hasProperty("sonatype_username") && project.hasProperty("sonatype_password"))
-        {
-            maven {
-                url = sonatype_staging_url
-                credentials {
-                    username = sonatype_username
-                    password = sonatype_password
-                }
-            }
-        }
-
         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
         {
             maven {
@@ -240,5 +230,24 @@ if (project.hasProperty("signing.keyId") && project.hasProperty("signing.passwor
     signing {
         sign publishing.publications.libs
     }
+}
+
+// Plugin that uses the New Maven Central Publishing (NMCP) API to publish Maven artifacts. https://github.com/GradleUp/nmcp
+nmcp {
+    centralPortal {
+        username = sonatype_username
+        password = sonatype_password
+        // publish manually from the portal
+        publishingType = "USER_MANAGED"
+//        // or if you want to publish automatically
+//        publishingType = "AUTOMATIC"
+    }
+}
+
+project.tasks.register('publishRelease', DefaultTask) {
+    DefaultTask task ->
+        task.group = 'Publishing'
+        task.description = 'Publish to Local repository and Maven Central'
+        task.dependsOn(tasks.publish, tasks.publishLibsPublicationToCentralPortal)
 }
 


### PR DESCRIPTION
#### Rationale
Issue [53059](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53059) - The endpoint/namespace we use for publishing our Java client libraries to Maven Central (`oss.sonatype.org`) has been deprecated and will cease to work as of June 30, 2025. Though there is no officially supported Gradle plugin for doing this publishing, our needs here are pretty simple, so we can use the simplest plugin referenced from [this doc](https://cookbook.gradle.org/integrations/maven-central/publishing/) from Gradle

#### Related Pull Requests
* https://github.com/LabKey/test_secure/pull/25/files

#### Changes
* Add nmcp plugin for publishing
* Add new `publishRelease` task 
* Remove usage of `sonatype_staging_url`
