### PR TITLE
Add workflowTaskId property to `ImportRunCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## version 7.1.0-SNAPSHOT
 *Released*: TBD
 * Gradle, Gradle plugins, commonsCodec, HttpClient, HttpCore version updates
+* Add workflowTaskId property to `ImportRunCommand`
 
 ## version 7.0.0
 *Released*: 18 July 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 7.1.0-SNAPSHOT
+## version 7.2.0-SNAPSHOT
 *Released*: TBD
+* 
+
+## version 7.1.0
+*Released*: 22 December 2025
 * Gradle, Gradle plugins, commonsCodec, HttpClient, HttpCore version updates
 * Add workflowTaskId property to `ImportRunCommand`
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "7.0.0-SNAPSHOT"
+version = "7.0.0-moveJobs-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "7.0.0-moveJobs-SNAPSHOT"
+version = "7.2.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/src/org/labkey/remoteapi/assay/ImportRunCommand.java
+++ b/src/org/labkey/remoteapi/assay/ImportRunCommand.java
@@ -41,6 +41,7 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
     private Map<String, Object> _properties;
     private Map<String, Object> _batchProperties;
     private String _auditUserComment;
+    private Integer _workflowTaskId;
 
     // Only one of the follow is allowed
     private List<Map<String, Object>> _dataRows;
@@ -122,6 +123,11 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
         _auditUserComment = auditUserComment;
     }
 
+    public void setWorkflowTaskId(Integer workflowTaskId)
+    {
+        _workflowTaskId = workflowTaskId;
+    }
+
     @Override
     protected ImportRunResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
@@ -165,6 +171,8 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
                 json.put("plateMetadata", _plateMetadata);
             if (_auditUserComment != null)
                 json.put("auditUserComment", _auditUserComment);
+            if (_workflowTaskId != null)
+                json.put("workflowTask", _workflowTaskId);
 
             builder.addTextBody("json", json.toString(), ContentType.APPLICATION_JSON);
         }
@@ -179,6 +187,8 @@ public class ImportRunCommand extends PostCommand<ImportRunResponse>
                 builder.addTextBody("comment", _comment);
             if (_auditUserComment != null)
                 builder.addTextBody("auditUserComment", _auditUserComment);
+            if (_workflowTaskId != null)
+                builder.addTextBody("workflowTask", String.valueOf(_workflowTaskId));
             if (_properties != null)
             {
                 for (Map.Entry<String, Object> entry : _properties.entrySet())


### PR DESCRIPTION
#### Rationale
When importing an assay run, we sometimes will associate a workflow task id with the run. 

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1238

#### Changes
* Add workflowTaskId property to `ImportRunCommand`
