### PR TITLE
Query: sort columns where name starts with '+'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## version 7.2.0-SNAPSHOT
 *Released*: TBD
+*
+
+## version 7.1.1
+*Released*: 10 February 2026
 * Explicit "+" sort direction
 
 ## version 7.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## version 7.2.0-SNAPSHOT
 *Released*: TBD
-* 
+* Explicit "+" sort direction
 
 ## version 7.1.0
 *Released*: 22 December 2025

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "7.2.0-SortDirection-SNAPSHOT"
+version = "7.2.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "7.2.0-SNAPSHOT"
+version = "7.2.0-SortDirection-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/src/org/labkey/remoteapi/query/Sort.java
+++ b/src/org/labkey/remoteapi/query/Sort.java
@@ -96,6 +96,6 @@ public class Sort
      */
     public String toQueryStringParam()
     {
-        return (getDirection() == Sort.Direction.DESCENDING ? "-" : "") + getColumnName();
+        return (getDirection() == Sort.Direction.DESCENDING ? "-" : "+") + getColumnName();
     }
 }


### PR DESCRIPTION
#### Rationale
This addresses [#442](https://github.com/LabKey/internal-issues/issues/442) by switching query sorting to explicitly state sort direction ('+' or '-').

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1935
- https://github.com/LabKey/labkey-api-java/pull/86
- https://github.com/LabKey/server/pull/1281
- https://github.com/LabKey/limsModules/pull/1977
- https://github.com/LabKey/platform/pull/7398

#### Changes
- Update query `Sort` to specify '+' for sort ascending
