### PR TITLE
Add Array operators to java api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## version 7.2.0-SNAPSHOT
 *Released*: TBD
-*
+* Add array filter types
 
 ## version 7.1.1
 *Released*: 10 February 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # The LabKey Remote API Library for Java - Change Log
 
-## version 7.2.0-SNAPSHOT
+## version 7.3.0-SNAPSHOT
 *Released*: TBD
+
+## version 7.2.0
+*Released*: 17 February 2026
 * Add array filter types
 
 ## version 7.1.1

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "7.2.0-ArrayFilterType-SNAPSHOT"
+version = "7.3.0-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 group = "org.labkey.api"
 
-version = "7.2.0-SNAPSHOT"
+version = "7.2.0-ArrayFilterType-SNAPSHOT"
 
 dependencies {
     api "org.json:json:${jsonObjectVersion}"

--- a/src/org/labkey/remoteapi/query/Filter.java
+++ b/src/org/labkey/remoteapi/query/Filter.java
@@ -39,6 +39,12 @@ public class Filter
         // These operators require a data value
         //
 
+        ARRAY_CONTAINS_ALL("Contains All", "arraycontainsall", "ARRAY_CONTAINS_ALL", true),
+        ARRAY_CONTAINS_ANY("Contains Any", "arraycontainsany", "ARRAY_CONTAINS_ANY", true),
+        ARRAY_CONTAINS_EXACT("Contains Exactly", "arraymatches", "ARRAY_CONTAINS_EXACT", true),
+        ARRAY_CONTAINS_NOT_EXACT("Does Not Contain Exactly", "arraynotmatches", "ARRAY_CONTAINS_NOT_EXACT", true),
+        ARRAY_CONTAINS_NONE("Contains None", "arraycontainsnone", "ARRAY_CONTAINS_NONE", true),
+
         EQUAL("Equals", "eq", "EQUAL", true),
         DATE_EQUAL("Equals", "dateeq", "DATE_EQUAL", true),
 
@@ -79,6 +85,9 @@ public class Filter
         //
         // These are the "no data value" operators
         //
+
+        ARRAY_ISEMPTY("Is Empty", "arrayisempty", "ARRAY_ISEMPTY", false),
+        ARRAY_ISNOTEMPTY("Is Not Empty", "arrayisnotempty", "ARRAY_ISNOTEMPTY", false),
 
         ISBLANK("Is Blank", "isblank", "MISSING", false),
         NONBLANK("Is Not Blank", "isnonblank", "NOT_MISSING", false),


### PR DESCRIPTION
#### Rationale
Update java api to incorporate new filter types for Array (Multi-value text choice) fields

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1287

#### Changes
* Added new Filter types for Array operations