### PR TITLE
Fix CHANGELOG to account for missing version 7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 *Released*: TBD
 
 ## version 7.2.0
-*Released*: 17 February 2026
+*Released*: ???
 * Add array filter types
-
-## version 7.1.1
-*Released*: 10 February 2026
 * Explicit "+" sort direction
 
 ## version 7.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 *Released*: TBD
 
 ## version 7.2.0
-*Released*: ???
+*Released*: 17 February 2026
 * Add array filter types
 * Explicit "+" sort direction
 


### PR DESCRIPTION
#### Rationale
We never actually [published 7.1.1](https://mvnrepository.com/artifact/org.labkey.api/labkey-client-api). We have another small fix, so I'm thinking we can just publish 7.2.0 with the changes intended for 7.1.1.

#### Related Pull Requests
* #86 

#### Changes
* Fix CHANGELOG to account for missing version 7.1.1
