### PR TITLE
Update HttpCore5 to 5.4.3 and HttpClient5 to 5.5.2 (CVE-2026-54399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## version 7.3.0-SNAPSHOT
 *Released*: TBD
 * Update Gradle version and remove some deprecated syntax
+* Update HttpCore5 to 5.4.3 (CVE-2026-54399) and HttpClient5 to 5.5.2
 
 ## version 7.2.0
 *Released*: 17 February 2026

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,8 @@ dependencies {
     api "org.json:json:${jsonObjectVersion}"
     api "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"
     api "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
+    // Pin httpcore5-h2 explicitly (arrives transitively via httpclient5) so the fixed 5.4.3 is declared in our POM. CVE-2026-54399.
+    api "org.apache.httpcomponents.core5:httpcore5-h2:${httpcore5Version}"
     implementation "commons-logging:commons-logging:${commonsLoggingVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,8 @@ gradlePluginsVersion=7.2.0
 commonsCodecVersion=1.20.0
 commonsLoggingVersion=1.3.5
 
-httpclient5Version=5.5.1
-httpcore5Version=5.3.6
+httpclient5Version=5.5.2
+httpcore5Version=5.4.3
 
 jsonObjectVersion=20250517
 


### PR DESCRIPTION
#### Rationale

CVE-2026-54399 (HIGH 7.5) affects Apache HttpComponents Core5 before 5.4.3 (both httpcore5 and httpcore5-h2) via HTTP/1.1 message-parser resource exhaustion. This library pinned httpcore5 5.3.6 and pulled httpcore5-h2 5.3.6 transitively - both flagged by LabKey Server's OWASP Dependency Check. Fixing here is the root-cause fix so downstream consumers (labkey-api-jdbc, LabKey Server) inherit the patched versions.

#### Related Pull Requests

* labkey-api-jdbc and LabKey Server PRs to follow once 7.3.0 is released

#### Changes

* Bump httpcore5 5.3.6 -> 5.4.3 (CVE-2026-54399)
* Declare httpcore5-h2 explicitly at 5.4.3 (was transitive at 5.3.6, same CVE)
* Align httpclient5 5.5.1 -> 5.5.2 with LabKey Server's proven pairing
* Add CHANGELOG entry under 7.3.0-SNAPSHOT
